### PR TITLE
L-01 Currencies Do Not Accept a Bond By Default

### DIFF
--- a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
@@ -55,6 +55,7 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     mapping(bytes32 => AddressWhitelistInterface) public customProposerWhitelists;
 
     // Admin controlled ranges limiting the changes that can be made by request managers.
+    // Unset currency -> (0,0) range; manager-set custom bonds revert until explicitly set.
     mapping(IERC20 => BondRange) public allowedBondRanges;
 
     // Admin controlled minimum liveness that can be set by request managers.
@@ -95,6 +96,7 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
 
         _setDefaultProposerWhitelist(_defaultProposerWhitelist);
         _setRequesterWhitelist(_requesterWhitelist);
+        // Explicit ranges enable manager-set custom bonds per currency (forbid-by-default).
         for (uint256 i = 0; i < _allowedBondRanges.length; i++) {
             _setAllowedBondRange(_allowedBondRanges[i].currency, _allowedBondRanges[i].range);
         }


### PR DESCRIPTION
We expect setting a bond range to be pretty rare, so we prefer a forbid-by-default behavior. Also, this doesn't prevent the OO from functioning, as `_validateBond` call is only used to validate a custom bond on `requestManagerSetBond` call. So we forbid request managers from setting a custom bond in currency by default. That should be fine