### PR TITLE
pm-v2-oo-reporter: standardize lifecycle event fields

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -53,6 +53,10 @@ Dispute callbacks and P4 settlements do not create replacement requests automati
 
 The owner can update the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active unresolved request with `setRequestRerequestBudget(...)`.
 
+Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
+the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,
+re-request-gate, rules-update, and resolution logs easy to correlate after a request has been replaced.
+
 ## Rules Updates
 
 Only the requester that registered a `requestId` can update rules for that request. Rules updates are stored as:

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -230,7 +230,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             RequestRulesUpdate({timestamp: block.timestamp, updatedRules: updatedRules});
         _getStorage().requestRulesUpdates[requestId].push(requestRulesUpdate);
 
-        emit RequestRulesUpdated(requestId, msg.sender, block.timestamp, updatedRules);
+        emit RequestRulesUpdated(requestId, block.timestamp, msg.sender, updatedRules);
     }
 
     /// @inheritdoc IOOReporter
@@ -283,8 +283,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         emit RequestRerequested(
             requestId,
-            msg.sender,
             request.requestTimestamp,
+            msg.sender,
             previousRequestTimestamp,
             address(rewardCurrency()),
             reward,
@@ -349,7 +349,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             request.outcome = price;
             request.rerequestAllowed = false;
 
-            emit RequestResolved(requestId, price);
+            emit RequestResolved(requestId, timestamp, price);
         }
     }
 

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -153,10 +153,10 @@ interface IOOReporter {
     );
     /// @notice Emitted when the registering requester posts updated request rules for offchain consumers.
     event RequestRulesUpdated(
-        bytes32 indexed requestId, address indexed updater, uint256 indexed timestamp, bytes updatedRules
+        bytes32 indexed requestId, uint256 indexed timestamp, address indexed updater, bytes updatedRules
     );
     /// @notice Emitted when a final raw UMA outcome is stored for a request.
-    event RequestResolved(bytes32 indexed requestId, int256 outcome);
+    event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
     /// @notice Emitted when a callback opens the approved-initializer re-request path.
     event RequestRerequestAllowed(
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
@@ -164,8 +164,8 @@ interface IOOReporter {
     /// @notice Emitted when UMA creates a replacement Managed OO request.
     event RequestRerequested(
         bytes32 indexed requestId,
-        address indexed rerequester,
         uint256 indexed requestTimestamp,
+        address indexed rerequester,
         uint256 previousRequestTimestamp,
         address rewardCurrency,
         uint256 reward,

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -61,15 +61,16 @@ contract OOReporterTest {
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     event RequestRulesUpdated(
-        bytes32 indexed requestId, address indexed updater, uint256 indexed timestamp, bytes updatedRules
+        bytes32 indexed requestId, uint256 indexed timestamp, address indexed updater, bytes updatedRules
     );
+    event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
     event RequestRerequestAllowed(
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
     );
     event RequestRerequested(
         bytes32 indexed requestId,
-        address indexed rerequester,
         uint256 indexed requestTimestamp,
+        address indexed rerequester,
         uint256 previousRequestTimestamp,
         address rewardCurrency,
         uint256 reward,
@@ -340,7 +341,7 @@ contract OOReporterTest {
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
         vm.expectEmit(address(reporter));
-        emit RequestRulesUpdated(REQUEST_ID, requester, block.timestamp, firstUpdatedRules);
+        emit RequestRulesUpdated(REQUEST_ID, block.timestamp, requester, firstUpdatedRules);
 
         vm.prank(requester);
         reporter.updateRequestRules(REQUEST_ID, firstUpdatedRules);
@@ -526,8 +527,8 @@ contract OOReporterTest {
         vm.expectEmit(address(reporter));
         emit RequestRerequested(
             REQUEST_ID,
-            oracleInitializer,
             block.timestamp,
+            oracleInitializer,
             request.requestTimestamp,
             address(usdc),
             REREQUEST_REWARD,
@@ -760,6 +761,9 @@ contract OOReporterTest {
         reporter.initializeRequest(requestId, 0, 0, LIVENESS);
 
         RequestData memory request = reporter.getRequest(requestId);
+        vm.expectEmit(address(reporter));
+        emit RequestResolved(requestId, request.requestTimestamp, price);
+
         optimisticOracle.settle(address(reporter), priceIdentifier, request.requestTimestamp, requestRules, price);
 
         assertTrue(reporter.isRequestResolved(requestId), "request should be resolved");


### PR DESCRIPTION
## What Changed

- Standardized request lifecycle event ordering so events that identify a Managed OO request lead with `requestId` followed by `requestTimestamp`.
- Reordered `RequestRulesUpdated` and `RequestRerequested` fields to match that convention.
- Added `requestTimestamp` to `RequestResolved` so resolution logs can be correlated to the active OO request after re-requests.
- Updated reporter tests and README event guidance to match the ABI change.

## Why

- The reporter already uses `requestId` as the canonical external join key, but lifecycle logs should still be consistent and easy for offchain indexers to consume.
- `RequestRerequested` previously placed the actor before `requestTimestamp`, unlike `RequestInitialized`.
- `RequestResolved` did not include the active OO timestamp, which made it less self-contained than the other callback-derived lifecycle events.

## Impact

- This is an ABI/event-signature change for the unaudited PM v2 reporter branch.
- Consumers decoding these events need to update their event signatures and positional field assumptions.
- Contract state and request lifecycle behavior are unchanged.

## High risk Sections to review with detail

- `pm-v2-oo-reporter/src/interfaces/IOOReporter.sol`: event signature changes for downstream ABI consumers.
- `pm-v2-oo-reporter/src/OOReporter.sol`: emit argument ordering and `RequestResolved` timestamp source.
- `pm-v2-oo-reporter/test/OOReporter.t.sol`: test-side mirrored event declarations and emit expectations.

## Validation

- Ran `git diff --check`.
- Did not run builds or tests per instruction.
