### PR TITLE
pm-v2-oo-reporter: add automatic re-request controls

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -60,9 +60,11 @@ P4 settlements reset the active request's manual budget to the current default. 
 P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are
 disabled, P4 settlements open the manual re-request gate instead.
 
-The owner can call `rerequest(requestId, reward)` while the manual gate is open and manual budget remains. The owner can
-update the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an
-active unresolved request with `setRequestRerequestBudget(...)`.
+The owner can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is open and manual
+budget remains. Manual re-requests can update the active reward, proposal bond, and liveness for the replacement request.
+Automatic re-requests reuse the active reward, proposal bond, and liveness. The owner can update the default budget for
+future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active unresolved request with
+`setRequestRerequestBudget(...)`.
 
 Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -52,9 +52,10 @@ liveness must be non-zero and inside the registered range. Each initialized requ
 `defaultRerequestBudget` as its manual re-request budget.
 
 Automatic re-requests are enabled by default and can be disabled or re-enabled by the owner with
-`setAutomaticRerequestsEnabled(...)`. When enabled, the first dispute callback for a request automatically creates one
-replacement request without consuming manual re-request budget. Later dispute callbacks open the manual re-request gate
-and emit `RequestRerequestAllowed`.
+`setAutomaticRerequestsEnabled(...)`. The current setting is evaluated when a dispute or P4 settlement callback arrives,
+not when the request was initialized or last re-requested. When enabled, the first dispute callback for a request
+automatically creates one replacement request without consuming manual re-request budget. Later dispute callbacks open
+the manual re-request gate and emit `RequestRerequestAllowed`.
 
 P4 settlements reset the active request's manual budget to the current default. When automatic re-requests are enabled,
 P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -33,7 +33,7 @@ function getRequestResolution(bytes32 requestId) external view returns (int256);
 - requester/module allowlisting;
 - UMA oracle initializer allowlisting;
 - Managed OO request creation;
-- reward, bond, request-specific liveness bounds, and re-request budget controls;
+- reward, bond, request-specific liveness bounds, automatic re-request controls, and manual re-request budget controls;
 - request rules update history for active requests;
 - raw UMA settlement storage.
 
@@ -47,11 +47,22 @@ The prediction market integration owns:
 
 An enabled requester first calls `registerRequest(...)` with its external `requestId`, UMA price identifier, raw request rules, and allowed liveness range. The reporter reserves the `(priceIdentifier, requestRules)` tuple globally so two request IDs cannot point at the same UMA request identity.
 
-An enabled UMA oracle initializer later calls `initializeRequest(requestId, reward, proposalBond, liveness)`. The selected liveness must be non-zero and inside the registered range. Each initialized request receives the current `defaultRerequestBudget`.
+An enabled UMA oracle initializer later calls `initializeRequest(requestId, reward, proposalBond, liveness)`. The selected
+liveness must be non-zero and inside the registered range. Each initialized request receives the current
+`defaultRerequestBudget` as its manual re-request budget.
 
-Dispute callbacks and P4 settlements do not create replacement requests automatically. They open the re-request gate and emit `RequestRerequestAllowed`. An enabled UMA oracle initializer can then call `rerequest(requestId, reward)` while budget remains. A P4 settlement on the active request resets the remaining re-request budget to the current default before opening the gate.
+Automatic re-requests are enabled by default and can be disabled or re-enabled by the owner with
+`setAutomaticRerequestsEnabled(...)`. When enabled, the first dispute callback for a request automatically creates one
+replacement request without consuming manual re-request budget. Later dispute callbacks open the manual re-request gate
+and emit `RequestRerequestAllowed`.
 
-The owner can update the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active unresolved request with `setRequestRerequestBudget(...)`.
+P4 settlements reset the active request's manual budget to the current default. When automatic re-requests are enabled,
+P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are
+disabled, P4 settlements open the manual re-request gate instead.
+
+The owner can call `rerequest(requestId, reward)` while the manual gate is open and manual budget remains. The owner can
+update the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an
+active unresolved request with `setRequestRerequestBudget(...)`.
 
 Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -8,7 +8,13 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
-import {IOOReporter, RequestData, RequestRulesUpdate, RerequestTrigger} from "./interfaces/IOOReporter.sol";
+import {
+    IOOReporter,
+    RequestData,
+    RequestRulesUpdate,
+    RerequestTrigger,
+    RerequestType
+} from "./interfaces/IOOReporter.sol";
 import {IOptimisticOracleV2} from "./interfaces/IOptimisticOracleV2.sol";
 import {IOptimisticRequester} from "./interfaces/IOptimisticRequester.sol";
 
@@ -53,6 +59,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         mapping(bytes32 requestId => RequestRulesUpdate[] updates) requestRulesUpdates;
         /// @notice Default re-request budget seeded onto each request at initialization.
         uint256 defaultRerequestBudget;
+        /// @notice Whether first-dispute and P4 automatic re-requests are enabled.
+        bool automaticRerequestsEnabled;
     }
 
     // keccak256(abi.encode(uint256(keccak256("uma.storage.OOReporter")) - 1)) & ~bytes32(uint256(0xff))
@@ -121,7 +129,9 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         }
 
         $.defaultRerequestBudget = initialDefaultRerequestBudget;
+        $.automaticRerequestsEnabled = true;
         emit DefaultRerequestBudgetSet(initialDefaultRerequestBudget);
+        emit AutomaticRerequestsEnabledSet(true);
     }
 
     /// @notice Returns the configured Managed Optimistic Oracle V2 address.
@@ -159,6 +169,11 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     /// @inheritdoc IOOReporter
+    function automaticRerequestsEnabled() public view returns (bool) {
+        return _getStorage().automaticRerequestsEnabled;
+    }
+
+    /// @inheritdoc IOOReporter
     function setRequesterEnabled(address requester, bool enabled) external onlyOwner {
         _setRequesterEnabled(requester, enabled);
     }
@@ -174,6 +189,14 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         _getStorage().defaultRerequestBudget = newDefaultRerequestBudget;
         emit DefaultRerequestBudgetSet(newDefaultRerequestBudget);
+    }
+
+    /// @inheritdoc IOOReporter
+    function setAutomaticRerequestsEnabled(bool enabled) external onlyOwner {
+        if (automaticRerequestsEnabled() == enabled) revert AutomaticRerequestsEnabledUnchanged();
+
+        _getStorage().automaticRerequestsEnabled = enabled;
+        emit AutomaticRerequestsEnabledSet(enabled);
     }
 
     /// @inheritdoc IOOReporter
@@ -244,14 +267,14 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         _requireValidRequestLiveness(request, liveness);
 
         uint256 requestTimestamp = block.timestamp;
-        uint256 rerequestsRemaining = defaultRerequestBudget();
+        uint256 manualRerequestsRemaining = defaultRerequestBudget();
         request.initialized = true;
         request.oracleInitializer = msg.sender;
         request.requestTimestamp = requestTimestamp;
         request.reward = reward;
         request.proposalBond = proposalBond;
         request.liveness = liveness;
-        request.rerequestsRemaining = rerequestsRemaining;
+        request.manualRerequestsRemaining = manualRerequestsRemaining;
 
         _requestPrice(request.priceIdentifier, requestTimestamp, request.requestRules, reward, proposalBond, liveness);
 
@@ -265,52 +288,44 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             reward,
             proposalBond,
             liveness,
-            rerequestsRemaining
+            manualRerequestsRemaining
         );
     }
 
     /// @inheritdoc IOOReporter
-    function rerequest(bytes32 requestId, uint256 reward) external onlyOracleInitializer {
+    function rerequest(bytes32 requestId, uint256 reward) external onlyOwner {
         RequestData storage request = _requireRegistered(requestId);
         if (!request.initialized) revert RequestNotInitialized();
         if (request.resolved) revert RequestAlreadyResolved();
         if (!request.rerequestAllowed) revert RequestRerequestNotAllowed();
-        if (request.rerequestsRemaining == 0) revert RequestRerequestBudgetExhausted();
+        if (request.manualRerequestsRemaining == 0) revert RequestRerequestBudgetExhausted();
 
         uint256 previousRequestTimestamp = _executeRerequest(request, reward, msg.sender);
 
-        request.rerequestsRemaining -= 1;
+        request.manualRerequestsRemaining -= 1;
 
-        emit RequestRerequested(
-            requestId,
-            request.requestTimestamp,
-            msg.sender,
-            previousRequestTimestamp,
-            address(rewardCurrency()),
-            reward,
-            request.proposalBond,
-            request.liveness,
-            request.rerequestsRemaining
-        );
+        _emitRequestRerequested(requestId, request, previousRequestTimestamp, msg.sender, RerequestType.Manual);
     }
 
     /// @inheritdoc IOOReporter
-    function setRequestRerequestBudget(bytes32 requestId, uint256 newRerequestsRemaining) external onlyOwner {
+    function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external onlyOwner {
         RequestData storage request = _requireRegistered(requestId);
         if (!request.initialized) revert RequestNotInitialized();
         if (request.resolved) revert RequestAlreadyResolved();
         uint256 budgetCeiling = defaultRerequestBudget();
-        if (newRerequestsRemaining > budgetCeiling) {
-            revert RequestRerequestBudgetAboveDefault(newRerequestsRemaining, budgetCeiling);
+        if (newManualRerequestsRemaining > budgetCeiling) {
+            revert RequestRerequestBudgetAboveDefault(newManualRerequestsRemaining, budgetCeiling);
         }
-        if (request.rerequestsRemaining == newRerequestsRemaining) revert RequestRerequestBudgetUnchanged();
+        if (request.manualRerequestsRemaining == newManualRerequestsRemaining) {
+            revert RequestRerequestBudgetUnchanged();
+        }
 
-        request.rerequestsRemaining = newRerequestsRemaining;
+        request.manualRerequestsRemaining = newManualRerequestsRemaining;
 
-        emit RequestRerequestBudgetSet(requestId, newRerequestsRemaining);
+        emit RequestRerequestBudgetSet(requestId, newManualRerequestsRemaining);
     }
 
-    /// @notice Managed OO dispute callback. Opens the oracle-initializer re-request gate for the active request.
+    /// @notice Managed OO dispute callback. Auto re-requests once, then opens the owner re-request gate.
     /// @inheritdoc IOptimisticRequester
     function priceDisputed(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256)
         external
@@ -321,10 +336,15 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             _loadCallbackRequest(identifier, timestamp, requestRules);
         if (shouldIgnore || request.resolved) return;
 
-        _allowRerequest(requestId, timestamp, request, RerequestTrigger.Dispute);
+        if (automaticRerequestsEnabled() && !request.automaticDisputeRerequestUsed) {
+            request.automaticDisputeRerequestUsed = true;
+            _executeAutomaticRerequest(requestId, request, RerequestType.AutomaticDispute);
+        } else {
+            _allowRerequest(requestId, timestamp, request, RerequestTrigger.Dispute);
+        }
     }
 
-    /// @notice Managed OO settlement callback. Stores final prices; resets the budget and opens re-request on P4.
+    /// @notice Managed OO settlement callback. Stores final prices; resets the budget and re-requests on P4.
     /// @inheritdoc IOptimisticRequester
     function priceSettled(bytes32 identifier, uint256 timestamp, bytes memory requestRules, int256 price)
         external
@@ -337,13 +357,17 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         if (price == P4_PRICE) {
             // Reporter requests are event-based, so Managed OO rejects proposed P4; P4 here is DVM-resolved.
-            // Refill the budget so the oracle initializer can continue without owner intervention, then reopen the gate.
+            // Refill the manual budget so the owner can continue without intervention if automation is disabled.
             uint256 budget = defaultRerequestBudget();
-            if (request.rerequestsRemaining != budget) {
-                request.rerequestsRemaining = budget;
+            if (request.manualRerequestsRemaining != budget) {
+                request.manualRerequestsRemaining = budget;
                 emit RequestRerequestBudgetSet(requestId, budget);
             }
-            _allowRerequest(requestId, timestamp, request, RerequestTrigger.InvalidSettlement);
+            if (automaticRerequestsEnabled()) {
+                _executeAutomaticRerequest(requestId, request, RerequestType.AutomaticInvalidSettlement);
+            } else {
+                _allowRerequest(requestId, timestamp, request, RerequestTrigger.InvalidSettlement);
+            }
         } else {
             request.resolved = true;
             request.outcome = price;
@@ -467,6 +491,36 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             reward,
             request.proposalBond,
             request.liveness
+        );
+    }
+
+    /// @dev Creates a replacement request without spending manual budget.
+    function _executeAutomaticRerequest(bytes32 requestId, RequestData storage request, RerequestType rerequestType)
+        private
+    {
+        uint256 previousRequestTimestamp = _executeRerequest(request, request.reward, address(this));
+        _emitRequestRerequested(requestId, request, previousRequestTimestamp, address(this), rerequestType);
+    }
+
+    /// @dev Emits the post-state for a replacement Managed OO request.
+    function _emitRequestRerequested(
+        bytes32 requestId,
+        RequestData storage request,
+        uint256 previousRequestTimestamp,
+        address rerequester,
+        RerequestType rerequestType
+    ) private {
+        emit RequestRerequested(
+            requestId,
+            request.requestTimestamp,
+            rerequester,
+            rerequestType,
+            previousRequestTimestamp,
+            address(rewardCurrency()),
+            request.reward,
+            request.proposalBond,
+            request.liveness,
+            request.manualRerequestsRemaining
         );
     }
 

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -293,14 +293,15 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     /// @inheritdoc IOOReporter
-    function rerequest(bytes32 requestId, uint256 reward) external onlyOwner {
+    function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external onlyOwner {
         RequestData storage request = _requireRegistered(requestId);
         if (!request.initialized) revert RequestNotInitialized();
         if (request.resolved) revert RequestAlreadyResolved();
         if (!request.rerequestAllowed) revert RequestRerequestNotAllowed();
         if (request.manualRerequestsRemaining == 0) revert RequestRerequestBudgetExhausted();
+        _requireValidRequestLiveness(request, liveness);
 
-        uint256 previousRequestTimestamp = _executeRerequest(request, reward, msg.sender);
+        uint256 previousRequestTimestamp = _executeRerequest(request, reward, proposalBond, liveness, msg.sender);
 
         request.manualRerequestsRemaining -= 1;
 
@@ -469,7 +470,13 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     --------------------------------------------------------------*/
 
     /// @dev Creates a replacement request with a strictly greater request timestamp than the previous request.
-    function _executeRerequest(RequestData storage request, uint256 reward, address oracleInitializer)
+    function _executeRerequest(
+        RequestData storage request,
+        uint256 reward,
+        uint256 proposalBond,
+        uint64 liveness,
+        address oracleInitializer
+    )
         private
         returns (uint256 previousRequestTimestamp)
     {
@@ -481,6 +488,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         request.requestTimestamp = requestTimestamp;
         request.reward = reward;
+        request.proposalBond = proposalBond;
+        request.liveness = liveness;
         request.oracleInitializer = oracleInitializer;
         request.rerequestAllowed = false;
 
@@ -489,8 +498,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             requestTimestamp,
             request.requestRules,
             reward,
-            request.proposalBond,
-            request.liveness
+            proposalBond,
+            liveness
         );
     }
 
@@ -498,7 +507,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     function _executeAutomaticRerequest(bytes32 requestId, RequestData storage request, RerequestType rerequestType)
         private
     {
-        uint256 previousRequestTimestamp = _executeRerequest(request, request.reward, address(this));
+        uint256 previousRequestTimestamp =
+            _executeRerequest(request, request.reward, request.proposalBond, request.liveness, address(this));
         _emitRequestRerequested(requestId, request, previousRequestTimestamp, address(this), rerequestType);
     }
 

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -284,7 +284,9 @@ interface IOOReporter {
     /// @notice Allows the owner to create a replacement Managed OO request after a callback opens the gate.
     /// @param requestId Registered request ID.
     /// @param reward Reward amount for the replacement request.
-    function rerequest(bytes32 requestId, uint256 reward) external;
+    /// @param proposalBond Bond required from OO proposers/disputers, or zero to use the OO default.
+    /// @param liveness Custom OO liveness period within the registered bounds.
+    function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Updates the remaining re-request budget for an initialized unresolved request.
     /// @param requestId Registered request ID.

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -18,9 +18,11 @@ struct RequestData {
     bool resolved;
     /// @notice Whether a re-request is currently allowed.
     bool rerequestAllowed;
+    /// @notice Whether this request has used its one automatic dispute re-request.
+    bool automaticDisputeRerequestUsed;
     /// @notice Approved requester that registered the request.
     address requester;
-    /// @notice UMA oracle initializer that created the active Managed OO request.
+    /// @notice Address that initiated the active Managed OO request.
     address oracleInitializer;
     /// @notice UMA price identifier for this request.
     bytes32 priceIdentifier;
@@ -28,8 +30,8 @@ struct RequestData {
     bytes requestRules;
     /// @notice Final raw UMA outcome after settlement.
     int256 outcome;
-    /// @notice Remaining oracle-initializer re-request budget. Seeded from the default at initialization and topped up by the owner.
-    uint256 rerequestsRemaining;
+    /// @notice Remaining manual re-request budget. Seeded from the default at initialization and topped up by the owner.
+    uint256 manualRerequestsRemaining;
     /// @notice Minimum liveness UMA is allowed to use for this request.
     uint64 minimumLiveness;
     /// @notice Maximum liveness UMA is allowed to use for this request.
@@ -48,6 +50,15 @@ enum RerequestTrigger {
     Dispute,
     /// @dev Managed OO settled to P4, so the request must be replaced.
     InvalidSettlement
+}
+
+enum RerequestType {
+    /// @dev Owner-triggered re-request that consumes the manual re-request budget.
+    Manual,
+    /// @dev First-dispute automatic re-request that does not consume the manual re-request budget.
+    AutomaticDispute,
+    /// @dev P4 settlement automatic re-request that does not consume the manual re-request budget.
+    AutomaticInvalidSettlement
 }
 
 /// @title IOOReporter
@@ -76,6 +87,8 @@ interface IOOReporter {
     error OracleInitializerEnabledUnchanged();
     /// @notice Thrown when a default re-request budget update would not change state.
     error DefaultRerequestBudgetUnchanged();
+    /// @notice Thrown when an automatic re-request setting update would not change state.
+    error AutomaticRerequestsEnabledUnchanged();
     /// @notice Thrown when a per-request re-request budget update would not change state.
     error RequestRerequestBudgetUnchanged();
     /// @notice Thrown when a per-request re-request budget top-up exceeds the contract-level default budget.
@@ -96,7 +109,7 @@ interface IOOReporter {
     error RequestRerequestNotAllowed();
     /// @notice Thrown when a replacement request timestamp does not advance.
     error RequestRerequestTimestampNotAdvanced(uint256 currentTimestamp, uint256 previousRequestTimestamp);
-    /// @notice Thrown when the oracle-initializer re-request budget is exhausted.
+    /// @notice Thrown when the manual re-request budget is exhausted.
     error RequestRerequestBudgetExhausted();
     /// @notice Thrown when raw request rules is empty or too large for the OO.
     error InvalidRequestRules();
@@ -129,6 +142,8 @@ interface IOOReporter {
     event OracleInitializerEnabledSet(address indexed oracleInitializer, bool enabled);
     /// @notice Emitted when the owner updates the default per-request re-request budget.
     event DefaultRerequestBudgetSet(uint256 defaultRerequestBudget);
+    /// @notice Emitted when the owner enables or disables automatic re-requests.
+    event AutomaticRerequestsEnabledSet(bool enabled);
     /// @notice Emitted when an approved requester registers a request for UMA initialization.
     event RequestRegistered(
         bytes32 indexed requestId,
@@ -149,7 +164,7 @@ interface IOOReporter {
         uint256 reward,
         uint256 proposalBond,
         uint64 liveness,
-        uint256 rerequestsRemaining
+        uint256 manualRerequestsRemaining
     );
     /// @notice Emitted when the registering requester posts updated request rules for offchain consumers.
     event RequestRulesUpdated(
@@ -157,24 +172,25 @@ interface IOOReporter {
     );
     /// @notice Emitted when a final raw UMA outcome is stored for a request.
     event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
-    /// @notice Emitted when a callback opens the approved-initializer re-request path.
+    /// @notice Emitted when a callback opens the owner re-request path.
     event RequestRerequestAllowed(
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
     );
-    /// @notice Emitted when UMA creates a replacement Managed OO request.
+    /// @notice Emitted when the reporter creates a replacement Managed OO request.
     event RequestRerequested(
         bytes32 indexed requestId,
         uint256 indexed requestTimestamp,
         address indexed rerequester,
+        RerequestType rerequestType,
         uint256 previousRequestTimestamp,
         address rewardCurrency,
         uint256 reward,
         uint256 proposalBond,
         uint64 liveness,
-        uint256 rerequestsRemaining
+        uint256 manualRerequestsRemaining
     );
     /// @notice Emitted when the owner updates the remaining re-request budget for one request.
-    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 rerequestsRemaining);
+    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 manualRerequestsRemaining);
     /// @notice Emitted when the owner sweeps ERC20 or native token funds from the reporter.
     event FundsSwept(address indexed token, address indexed recipient, uint256 amount);
     /// @notice Emitted when the owner claims a deferred Managed OO payout owed to the reporter.
@@ -214,6 +230,10 @@ interface IOOReporter {
     /// @param newDefaultRerequestBudget New default re-request budget.
     function setDefaultRerequestBudget(uint256 newDefaultRerequestBudget) external;
 
+    /// @notice Enables or disables automatic dispute and P4 re-requests.
+    /// @param enabled Whether automatic re-requests should be enabled.
+    function setAutomaticRerequestsEnabled(bool enabled) external;
+
     /// @notice Returns whether candidate is approved to register requests.
     /// @param candidate Address to check.
     /// @return True if candidate is an enabled requester.
@@ -227,6 +247,10 @@ interface IOOReporter {
     /// @notice Returns the default replacement-request budget seeded onto each initialized request.
     /// @return Current default re-request budget.
     function defaultRerequestBudget() external view returns (uint256);
+
+    /// @notice Returns whether automatic dispute and P4 re-requests are enabled.
+    /// @return True if automatic re-requests are enabled.
+    function automaticRerequestsEnabled() external view returns (bool);
 
     /// @notice Registers a requester-defined request ID and its UMA request identity before OO initialization.
     /// @dev The reporter reserves each price identifier and request rules pair globally across approved requesters.
@@ -257,15 +281,15 @@ interface IOOReporter {
     /// @param liveness Custom OO liveness period within the registered bounds.
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
-    /// @notice Allows UMA to create a replacement Managed OO request after a callback opens the gate.
+    /// @notice Allows the owner to create a replacement Managed OO request after a callback opens the gate.
     /// @param requestId Registered request ID.
     /// @param reward Reward amount for the replacement request.
     function rerequest(bytes32 requestId, uint256 reward) external;
 
     /// @notice Updates the remaining re-request budget for an initialized unresolved request.
     /// @param requestId Registered request ID.
-    /// @param newRerequestsRemaining New remaining re-request budget, capped by the current default.
-    function setRequestRerequestBudget(bytes32 requestId, uint256 newRerequestsRemaining) external;
+    /// @param newManualRerequestsRemaining New remaining manual re-request budget, capped by the current default.
+    function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external;
 
     /// @notice Returns whether a final reporter outcome is available for requestId.
     /// @param requestId Registered request ID.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -524,6 +524,73 @@ contract OOReporterTest {
         assertEq(allowedRequest.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "gate should not consume budget");
     }
 
+    function test_priceDisputedUsesCurrentAutomationSettingAfterDisabledFirstDispute() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.Dispute);
+
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory afterDisabledDispute = reporter.getRequest(REQUEST_ID);
+        assertTrue(afterDisabledDispute.rerequestAllowed, "disabled first dispute should open manual gate");
+        assertFalse(
+            afterDisabledDispute.automaticDisputeRerequestUsed,
+            "disabled first dispute should not consume automatic slot"
+        );
+        assertEq(
+            afterDisabledDispute.requestTimestamp,
+            request.requestTimestamp,
+            "disabled first dispute should not advance timestamp"
+        );
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(owner);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(true);
+        vm.warp(block.timestamp + 1);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequested(
+            REQUEST_ID,
+            block.timestamp,
+            address(reporter),
+            RerequestType.AutomaticDispute,
+            afterManual.requestTimestamp,
+            address(usdc),
+            0,
+            PROPOSAL_BOND,
+            LIVENESS,
+            DEFAULT_REREQUEST_BUDGET - 1
+        );
+
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, afterManual.requestTimestamp, requestRules);
+
+        RequestData memory afterAuto = reporter.getRequest(REQUEST_ID);
+        assertFalse(afterAuto.rerequestAllowed, "enabled later dispute should auto re-request");
+        assertTrue(afterAuto.automaticDisputeRerequestUsed, "enabled later dispute should consume automatic slot");
+        assertEq(afterAuto.requestTimestamp, block.timestamp, "enabled later dispute should advance timestamp");
+        assertEq(
+            afterAuto.manualRerequestsRemaining,
+            DEFAULT_REREQUEST_BUDGET - 1,
+            "automatic re-request should not consume budget"
+        );
+    }
+
     function test_priceSettledP4ResetsBudgetAndAutomaticallyRerequests() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
@@ -605,6 +672,37 @@ contract OOReporterTest {
         assertTrue(afterP4.rerequestAllowed, "disabled P4 automation should open manual gate");
         assertEq(afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp");
         assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available");
+    }
+
+    function test_priceSettledP4UsesCurrentAutomationSettingAfterBeingDisabled() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+        vm.warp(block.timestamp + 1);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.InvalidSettlement);
+
+        optimisticOracle.settle(
+            address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, reporter.P4_PRICE()
+        );
+
+        RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
+        assertTrue(afterP4.rerequestAllowed, "disabled P4 callback should open manual gate");
+        assertFalse(afterP4.resolved, "P4 should not resolve request");
+        assertEq(
+            afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 callback should not advance timestamp"
+        );
+        assertEq(
+            afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "disabled P4 should leave budget available"
+        );
     }
 
     function test_rerequestConsumesBudgetAndCreatesReplacementRequest() external {

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -2,7 +2,13 @@
 pragma solidity 0.8.34;
 
 import {OOReporter} from "src/OOReporter.sol";
-import {IOOReporter, RequestData, RequestRulesUpdate, RerequestTrigger} from "src/interfaces/IOOReporter.sol";
+import {
+    IOOReporter,
+    RequestData,
+    RequestRulesUpdate,
+    RerequestTrigger,
+    RerequestType
+} from "src/interfaces/IOOReporter.sol";
 import {MockERC20} from "test/mocks/MockERC20.sol";
 import {MockOptimisticOracleV2} from "test/mocks/MockOptimisticOracleV2.sol";
 
@@ -71,15 +77,17 @@ contract OOReporterTest {
         bytes32 indexed requestId,
         uint256 indexed requestTimestamp,
         address indexed rerequester,
+        RerequestType rerequestType,
         uint256 previousRequestTimestamp,
         address rewardCurrency,
         uint256 reward,
         uint256 proposalBond,
         uint64 liveness,
-        uint256 rerequestsRemaining
+        uint256 manualRerequestsRemaining
     );
-    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 rerequestsRemaining);
+    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 manualRerequestsRemaining);
     event DefaultRerequestBudgetSet(uint256 defaultRerequestBudget);
+    event AutomaticRerequestsEnabledSet(bool enabled);
 
     bytes32 internal constant REQUEST_ID = keccak256("request-id");
     bytes32 internal constant SECOND_REQUEST_ID = keccak256("second-request-id");
@@ -255,7 +263,11 @@ contract OOReporterTest {
         assertEq(request.liveness, LIVENESS, "liveness mismatch");
         assertEq(request.minimumLiveness, MINIMUM_LIVENESS, "minimum liveness mismatch");
         assertEq(request.maximumLiveness, MAXIMUM_LIVENESS, "maximum liveness mismatch");
-        assertEq(request.rerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "re-request budget should seed from default");
+        assertEq(
+            request.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "re-request budget should seed from default"
+        );
+        assertFalse(request.automaticDisputeRerequestUsed, "automatic dispute re-request should start unused");
+        assertTrue(reporter.automaticRerequestsEnabled(), "automatic re-requests should initialize enabled");
 
         bytes32 requestKey =
             optimisticOracle.requestKey(address(reporter), NUMERICAL_IDENTIFIER, block.timestamp, requestRules);
@@ -450,7 +462,7 @@ contract OOReporterTest {
         );
     }
 
-    function test_priceDisputedOpensRerequestGateWithoutConsumingBudget() external {
+    function test_priceDisputedAutomaticallyRerequestsOnceWithoutConsumingBudget() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
@@ -461,66 +473,150 @@ contract OOReporterTest {
         vm.warp(block.timestamp + 1);
 
         vm.expectEmit(address(reporter));
-        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.Dispute);
+        emit RequestRerequested(
+            REQUEST_ID,
+            block.timestamp,
+            address(reporter),
+            RerequestType.AutomaticDispute,
+            request.requestTimestamp,
+            address(usdc),
+            0,
+            PROPOSAL_BOND,
+            LIVENESS,
+            DEFAULT_REREQUEST_BUDGET
+        );
 
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
 
-        RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
-        assertTrue(allowedRequest.rerequestAllowed, "dispute should open the re-request gate");
-        assertFalse(allowedRequest.resolved, "dispute should not resolve the request");
-        assertEq(allowedRequest.requestTimestamp, request.requestTimestamp, "dispute should not advance timestamp");
-        assertEq(allowedRequest.rerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "dispute should not consume budget");
+        RequestData memory afterAuto = reporter.getRequest(REQUEST_ID);
+        assertFalse(afterAuto.rerequestAllowed, "automatic re-request should not leave gate open");
+        assertFalse(afterAuto.resolved, "dispute should not resolve the request");
+        assertTrue(afterAuto.automaticDisputeRerequestUsed, "automatic dispute re-request should be marked used");
+        assertEq(afterAuto.requestTimestamp, block.timestamp, "automatic dispute should advance timestamp");
+        assertEq(afterAuto.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "dispute should not consume budget");
     }
 
-    function test_priceSettledP4ResetsBudgetAndOpensRerequestGateWithoutRerequesting() external {
+    function test_priceDisputedOpensManualGateAfterAutomaticDisputeUsed() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
-        // Spend one re-request so we can prove a P4 on the active request refills the budget to the default.
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory afterAuto = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, afterAuto.requestTimestamp, RerequestTrigger.Dispute);
+
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, afterAuto.requestTimestamp, requestRules);
+
+        RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
+        assertTrue(allowedRequest.rerequestAllowed, "second dispute should open the manual gate");
+        assertTrue(allowedRequest.automaticDisputeRerequestUsed, "automatic dispute re-request should stay used");
+        assertEq(allowedRequest.requestTimestamp, afterAuto.requestTimestamp, "manual gate should not advance timestamp");
+        assertEq(allowedRequest.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "gate should not consume budget");
+    }
+
+    function test_priceSettledP4ResetsBudgetAndAutomaticallyRerequests() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+
         vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        // Spend one manual re-request so we can prove P4 refills the manual budget to the default.
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+        vm.prank(owner);
         reporter.rerequest(REQUEST_ID, 0);
 
-        RequestData memory afterRerequest = reporter.getRequest(REQUEST_ID);
-        assertEq(afterRerequest.rerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement once");
+        RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
+        assertEq(afterManual.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement once");
 
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(true);
         vm.warp(block.timestamp + 1);
+
         vm.expectEmit(address(reporter));
         emit RequestRerequestBudgetSet(REQUEST_ID, DEFAULT_REREQUEST_BUDGET);
         vm.expectEmit(address(reporter));
-        emit RequestRerequestAllowed(REQUEST_ID, afterRerequest.requestTimestamp, RerequestTrigger.InvalidSettlement);
+        emit RequestRerequested(
+            REQUEST_ID,
+            block.timestamp,
+            address(reporter),
+            RerequestType.AutomaticInvalidSettlement,
+            afterManual.requestTimestamp,
+            address(usdc),
+            0,
+            PROPOSAL_BOND,
+            LIVENESS,
+            DEFAULT_REREQUEST_BUDGET
+        );
 
         optimisticOracle.settle(
-            address(reporter), BINARY_IDENTIFIER, afterRerequest.requestTimestamp, requestRules, reporter.P4_PRICE()
+            address(reporter), BINARY_IDENTIFIER, afterManual.requestTimestamp, requestRules, reporter.P4_PRICE()
         );
 
         RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
         assertFalse(afterP4.resolved, "P4 should not resolve request");
         assertFalse(reporter.isRequestResolved(REQUEST_ID), "P4 should not resolve request");
-        assertTrue(afterP4.rerequestAllowed, "P4 should open the re-request gate");
-        assertEq(afterP4.rerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default");
-        assertEq(afterP4.requestTimestamp, afterRerequest.requestTimestamp, "P4 must not auto re-request");
+        assertFalse(afterP4.rerequestAllowed, "automatic P4 re-request should not leave gate open");
+        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default");
+        assertEq(afterP4.requestTimestamp, block.timestamp, "P4 should auto re-request");
 
         vm.expectRevert(IOOReporter.RequestResolutionUnavailable.selector);
         reporter.getRequestResolution(REQUEST_ID);
     }
 
+    function test_priceSettledP4OpensManualGateWhenAutomaticRerequestsDisabled() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.InvalidSettlement);
+
+        optimisticOracle.settle(
+            address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, reporter.P4_PRICE()
+        );
+
+        RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
+        assertTrue(afterP4.rerequestAllowed, "disabled P4 automation should open manual gate");
+        assertEq(afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp");
+        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available");
+    }
+
     function test_rerequestConsumesBudgetAndCreatesReplacementRequest() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
-        usdc.mint(address(reporter), REWARD);
 
         vm.prank(oracleInitializer);
-        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory afterAuto = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, afterAuto.requestTimestamp, requestRules);
 
         usdc.mint(address(reporter), REREQUEST_REWARD);
 
@@ -528,8 +624,9 @@ contract OOReporterTest {
         emit RequestRerequested(
             REQUEST_ID,
             block.timestamp,
-            oracleInitializer,
-            request.requestTimestamp,
+            owner,
+            RerequestType.Manual,
+            afterAuto.requestTimestamp,
             address(usdc),
             REREQUEST_REWARD,
             PROPOSAL_BOND,
@@ -537,13 +634,13 @@ contract OOReporterTest {
             DEFAULT_REREQUEST_BUDGET - 1
         );
 
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         reporter.rerequest(REQUEST_ID, REREQUEST_REWARD);
 
         RequestData memory rerequested = reporter.getRequest(REQUEST_ID);
         assertEq(rerequested.requestTimestamp, block.timestamp, "re-request timestamp mismatch");
         assertEq(rerequested.reward, REREQUEST_REWARD, "re-request reward mismatch");
-        assertEq(rerequested.rerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement");
+        assertEq(rerequested.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement");
         assertFalse(rerequested.rerequestAllowed, "gate should close after re-request");
 
         bytes32 requestKey =
@@ -561,11 +658,11 @@ contract OOReporterTest {
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         vm.prank(unauthorized);
-        vm.expectRevert(IOOReporter.CallerNotOracleInitializer.selector);
+        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("OwnableUnauthorizedAccount(address)")), unauthorized));
         reporter.rerequest(REQUEST_ID, 0);
 
         vm.warp(block.timestamp + 1);
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestRerequestNotAllowed.selector);
         reporter.rerequest(REQUEST_ID, 0);
     }
@@ -577,6 +674,8 @@ contract OOReporterTest {
         // Seed a small budget so it can be exhausted in a couple of re-requests.
         vm.prank(owner);
         reporter.setDefaultRerequestBudget(2);
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
 
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
@@ -587,11 +686,11 @@ contract OOReporterTest {
 
         // Budget exhausted: gate is open again, but the re-request must revert.
         RequestData memory exhausted = reporter.getRequest(REQUEST_ID);
-        assertEq(exhausted.rerequestsRemaining, 0, "budget should be exhausted");
+        assertEq(exhausted.manualRerequestsRemaining, 0, "budget should be exhausted");
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, exhausted.requestTimestamp, requestRules);
 
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestRerequestBudgetExhausted.selector);
         reporter.rerequest(REQUEST_ID, 0);
 
@@ -606,10 +705,10 @@ contract OOReporterTest {
         vm.prank(owner);
         reporter.setRequestRerequestBudget(REQUEST_ID, 2);
 
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         reporter.rerequest(REQUEST_ID, 0);
 
-        assertEq(reporter.getRequest(REQUEST_ID).rerequestsRemaining, 1, "budget should reflect top-up minus one");
+        assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 1, "budget should reflect top-up minus one");
     }
 
     function test_setRequestRerequestBudgetRejectsUnauthorizedUnchangedAndResolved() external {
@@ -666,7 +765,31 @@ contract OOReporterTest {
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
-        assertEq(reporter.getRequest(REQUEST_ID).rerequestsRemaining, 4, "request should seed new default budget");
+        assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 4, "request should seed new default budget");
+    }
+
+    function test_setAutomaticRerequestsEnabledUpdatesAndRejectsInvalidChanges() external {
+        assertTrue(reporter.automaticRerequestsEnabled(), "automatic re-requests should start enabled");
+
+        vm.prank(unauthorized);
+        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("OwnableUnauthorizedAccount(address)")), unauthorized));
+        reporter.setAutomaticRerequestsEnabled(false);
+
+        vm.prank(owner);
+        vm.expectRevert(IOOReporter.AutomaticRerequestsEnabledUnchanged.selector);
+        reporter.setAutomaticRerequestsEnabled(true);
+
+        vm.expectEmit(address(reporter));
+        emit AutomaticRerequestsEnabledSet(false);
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+        assertFalse(reporter.automaticRerequestsEnabled(), "automatic re-requests should disable");
+
+        vm.expectEmit(address(reporter));
+        emit AutomaticRerequestsEnabledSet(true);
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(true);
+        assertTrue(reporter.automaticRerequestsEnabled(), "automatic re-requests should re-enable");
     }
 
     function test_priceSettledRejectsUnauthorizedCallerAndIgnoresUnknownTuples() external {
@@ -688,10 +811,8 @@ contract OOReporterTest {
         RequestData memory firstRequest = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
 
-        // Dispute opens the gate; a manual re-request then advances the active timestamp.
+        // The first dispute automatically creates a replacement request and advances the active timestamp.
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, firstRequest.requestTimestamp, requestRules);
-        vm.prank(oracleInitializer);
-        reporter.rerequest(REQUEST_ID, 0);
 
         RequestData memory activeRequest = reporter.getRequest(REQUEST_ID);
         assertEq(activeRequest.requestTimestamp, block.timestamp, "active timestamp should advance");
@@ -717,7 +838,7 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         optimisticOracle.settle(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, 1 ether);
 
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
         reporter.rerequest(REQUEST_ID, REREQUEST_REWARD);
 
@@ -730,7 +851,7 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
-        vm.prank(oracleInitializer);
+        vm.prank(owner);
         reporter.rerequest(REQUEST_ID, 0);
     }
 

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -96,7 +96,9 @@ contract OOReporterTest {
     uint256 internal constant REWARD = 2_000_000;
     uint256 internal constant REREQUEST_REWARD = 3_000_000;
     uint256 internal constant PROPOSAL_BOND = 500_000_000;
+    uint256 internal constant MANUAL_PROPOSAL_BOND = 700_000_000;
     uint64 internal constant LIVENESS = 7200;
+    uint64 internal constant MANUAL_LIVENESS = 3 hours;
     uint256 internal constant DEFAULT_REREQUEST_BUDGET = 10;
     uint64 internal constant MINIMUM_LIVENESS = 0;
     uint64 internal constant MAXIMUM_LIVENESS = 2 days;
@@ -537,7 +539,7 @@ contract OOReporterTest {
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
         vm.prank(owner);
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, MANUAL_PROPOSAL_BOND, MANUAL_LIVENESS);
 
         RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
         assertEq(afterManual.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement once");
@@ -557,8 +559,8 @@ contract OOReporterTest {
             afterManual.requestTimestamp,
             address(usdc),
             0,
-            PROPOSAL_BOND,
-            LIVENESS,
+            MANUAL_PROPOSAL_BOND,
+            MANUAL_LIVENESS,
             DEFAULT_REREQUEST_BUDGET
         );
 
@@ -572,6 +574,8 @@ contract OOReporterTest {
         assertFalse(afterP4.rerequestAllowed, "automatic P4 re-request should not leave gate open");
         assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default");
         assertEq(afterP4.requestTimestamp, block.timestamp, "P4 should auto re-request");
+        assertEq(afterP4.proposalBond, MANUAL_PROPOSAL_BOND, "P4 should preserve latest manual bond");
+        assertEq(afterP4.liveness, MANUAL_LIVENESS, "P4 should preserve latest manual liveness");
 
         vm.expectRevert(IOOReporter.RequestResolutionUnavailable.selector);
         reporter.getRequestResolution(REQUEST_ID);
@@ -629,17 +633,19 @@ contract OOReporterTest {
             afterAuto.requestTimestamp,
             address(usdc),
             REREQUEST_REWARD,
-            PROPOSAL_BOND,
-            LIVENESS,
+            MANUAL_PROPOSAL_BOND,
+            MANUAL_LIVENESS,
             DEFAULT_REREQUEST_BUDGET - 1
         );
 
         vm.prank(owner);
-        reporter.rerequest(REQUEST_ID, REREQUEST_REWARD);
+        reporter.rerequest(REQUEST_ID, REREQUEST_REWARD, MANUAL_PROPOSAL_BOND, MANUAL_LIVENESS);
 
         RequestData memory rerequested = reporter.getRequest(REQUEST_ID);
         assertEq(rerequested.requestTimestamp, block.timestamp, "re-request timestamp mismatch");
         assertEq(rerequested.reward, REREQUEST_REWARD, "re-request reward mismatch");
+        assertEq(rerequested.proposalBond, MANUAL_PROPOSAL_BOND, "re-request bond mismatch");
+        assertEq(rerequested.liveness, MANUAL_LIVENESS, "re-request liveness mismatch");
         assertEq(rerequested.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement");
         assertFalse(rerequested.rerequestAllowed, "gate should close after re-request");
 
@@ -647,7 +653,8 @@ contract OOReporterTest {
             optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
         MockOptimisticOracleV2.MockRequest memory ooRequest = optimisticOracle.getMockRequest(requestKey);
         assertTrue(ooRequest.requested, "replacement request should exist");
-        assertEq(ooRequest.customLiveness, LIVENESS, "replacement request liveness mismatch");
+        assertEq(ooRequest.bond, MANUAL_PROPOSAL_BOND, "replacement request bond mismatch");
+        assertEq(ooRequest.customLiveness, MANUAL_LIVENESS, "replacement request liveness mismatch");
     }
 
     function test_rerequestRevertsWhenGateClosedOrUnauthorized() external {
@@ -659,12 +666,40 @@ contract OOReporterTest {
 
         vm.prank(unauthorized);
         vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("OwnableUnauthorizedAccount(address)")), unauthorized));
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         vm.warp(block.timestamp + 1);
         vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestRerequestNotAllowed.selector);
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+    }
+
+    function test_rerequestRejectsManualLivenessOutsideRegisteredRange() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequestWithLivenessRange(
+            REQUEST_ID, BINARY_IDENTIFIER, requestRules, STRICT_MINIMUM_LIVENESS, STRICT_MAXIMUM_LIVENESS
+        );
+
+        vm.prank(owner);
+        reporter.setAutomaticRerequestsEnabled(false);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, STRICT_MINIMUM_LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOOReporter.RequestLivenessOutOfRange.selector,
+                STRICT_MAXIMUM_LIVENESS + 1,
+                STRICT_MINIMUM_LIVENESS,
+                STRICT_MAXIMUM_LIVENESS
+            )
+        );
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, STRICT_MAXIMUM_LIVENESS + 1);
     }
 
     function test_rerequestBudgetExhaustsAndOwnerCanTopUp() external {
@@ -692,7 +727,7 @@ contract OOReporterTest {
 
         vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestRerequestBudgetExhausted.selector);
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         // Owner cannot top a request up beyond the contract-level default budget.
         vm.prank(owner);
@@ -706,7 +741,7 @@ contract OOReporterTest {
         reporter.setRequestRerequestBudget(REQUEST_ID, 2);
 
         vm.prank(owner);
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 1, "budget should reflect top-up minus one");
     }
@@ -840,7 +875,7 @@ contract OOReporterTest {
 
         vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
-        reporter.rerequest(REQUEST_ID, REREQUEST_REWARD);
+        reporter.rerequest(REQUEST_ID, REREQUEST_REWARD, PROPOSAL_BOND, LIVENESS);
 
         vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
@@ -852,7 +887,7 @@ contract OOReporterTest {
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
         vm.prank(owner);
-        reporter.rerequest(REQUEST_ID, 0);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
     }
 
     function _registerRequest(bytes32 requestId, bytes32 priceIdentifier, bytes memory requestRules) internal {


### PR DESCRIPTION
## What Changed

- Added automatic replacement-request support to `OOReporter`.
- Added a global owner-controlled `automaticRerequestsEnabled` switch, enabled by default at initialization.
- Added per-request `automaticDisputeRerequestUsed` state so each registered request gets at most one automatic dispute re-request.
- Changed manual `rerequest(requestId, reward, proposalBond, liveness)` to be owner-only and to spend the renamed `manualRerequestsRemaining` budget.
- Allowed manual re-requests to update the active replacement request reward, proposal bond, and liveness.
- Kept automatic re-requests on the active stored reward, proposal bond, and liveness.
- Added `RerequestType` to `RequestRerequested` so indexers can distinguish `Manual`, `AutomaticDispute`, and `AutomaticInvalidSettlement` replacement requests.
- Updated tests and README lifecycle docs for automatic dispute/P4 behavior, owner-only manual re-requests, dynamic manual settings, and manual budget semantics.

## Why

- The reporter should automatically create one replacement request on the first dispute without consuming manual budget.
- Later disputes should require explicit owner/admin action through the manual re-request path.
- DVM P4 settlements should independently create a replacement request when automation is enabled, regardless of whether the first-dispute automatic re-request was already used.
- Operators need a simple global kill switch that falls back to the manual re-request gate.
- Operators also need to adjust reward, bond, and liveness on later manual re-requests as market conditions change.

## Impact

- This is an ABI/event/storage-shape change for the unaudited PM v2 reporter branch.
- Automatic re-requests reuse the active request reward, bond, liveness, identifier, and rules.
- Manual re-requests can update reward, proposal bond, and liveness for the replacement request.
- If a manual re-request updates bond or liveness, later automatic P4 replacement requests reuse those latest stored settings.
- Automatic re-requests do not consume manual budget.
- Manual re-requests are owner-only and consume `manualRerequestsRemaining`.
- If automatic re-requests are disabled, disputes and P4 settlements open the manual gate using `RequestRerequestAllowed`.

## High risk Sections to review with detail

- `pm-v2-oo-reporter/src/OOReporter.sol`: callback paths now create replacement OO requests directly from `priceDisputed` and P4 `priceSettled`.
- `pm-v2-oo-reporter/src/OOReporter.sol`: manual `rerequest` now validates and stores caller-supplied `proposalBond` and `liveness` before creating the replacement request.
- `pm-v2-oo-reporter/src/interfaces/IOOReporter.sol`: ABI changes for `RequestData`, `RequestRerequested`, the automatic toggle, manual budget naming, and the expanded manual `rerequest` signature.
- `pm-v2-oo-reporter/test/OOReporter.t.sol`: state-machine expectations for first dispute, later disputes, P4 automation, disabled automation, owner-only manual re-requests, and dynamic manual bond/liveness updates.
- Automatic replacement requests use the active reward, bond, and liveness; callback transactions can revert if the reporter is not funded for a nonzero automatic replacement reward.

## Validation

- Ran `git diff --check`.
- Did not run builds or tests per instruction.
