### PR TITLE
managed-oo: disallow same-block disputes

### DIFF
--- a/script/README.md
+++ b/script/README.md
@@ -297,6 +297,7 @@ The `ManagedOptimisticOracleV2` contract:
 - Allows request managers to set custom bonds, liveness, and proposer whitelists
 - Enforces maximum bonds and minimum liveness set by admins
 - Requires whitelisted requesters and proposers
+- Rejects disputes attempted in the same block as the proposal
 
 ## ManagedOptimisticOracleV2 Upgrade
 

--- a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
@@ -379,6 +379,35 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     }
 
     /**
+     * @notice Disputes a price value on another address' behalf.
+     * @dev Managed OO requires at least one block timestamp tick between proposal and dispute. This preserves the
+     *      request timestamp namespace for callback-driven replacement requests.
+     * @param disputer address to set as the disputer.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return totalBond the amount that's pulled from the caller's wallet as a bond.
+     */
+    function disputePriceFor(
+        address disputer,
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) public override returns (uint256 totalBond) {
+        require(disputer != address(0), DisputerAddressCannotBeZero());
+        require(
+            _getStateForDispute(requester, identifier, timestamp, ancillaryData) == State.Proposed,
+            RequestStateNotProposed()
+        );
+        Request storage request = _getRequest(requester, identifier, timestamp, ancillaryData);
+        require(request.proposalTime != getCurrentTime(), SameBlockDisputeNotAllowed());
+
+        return super.disputePriceFor(disputer, requester, identifier, timestamp, ancillaryData);
+    }
+
+    /**
      * @notice Retrieves a price that was previously requested by a caller. Reverts if the request is not settled yet.
      * @dev The naming of this method might be misleading as it does not actually settle the request, but it is required
      * for compatibility with the overridden parent contract method and restricts the settlement to the resolver role.

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -454,7 +454,7 @@ contract OptimisticOracleV2 is
         bytes32 identifier,
         uint256 timestamp,
         bytes memory ancillaryData
-    ) public override nonReentrant returns (uint256 totalBond) {
+    ) public virtual override nonReentrant returns (uint256 totalBond) {
         require(disputer != address(0), DisputerAddressCannotBeZero());
         require(
             _getStateForDispute(requester, identifier, timestamp, ancillaryData) == State.Proposed,

--- a/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
@@ -31,6 +31,8 @@ abstract contract ManagedOptimisticOracleV2Interface {
     error MinimumDisputeWindowTooLarge();
     /// @notice Thrown when minimum dispute window is smaller than the hard limit set in the contract.
     error MinimumDisputeWindowTooSmall();
+    /// @notice Thrown when a dispute is attempted in the same block as the proposal.
+    error SameBlockDisputeNotAllowed();
     /// @notice Thrown in settleAndGetPrice if the request has not been settled by resolver.
     error RequestNotSettled();
 

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -520,6 +520,26 @@ contract ManagedOptimisticOracleV2Test is Test {
         );
     }
 
+    function testDisputeRejectsSameBlockProposal() external {
+        uint256 t = block.timestamp;
+        _makeRequest(requester, t, 0);
+
+        _proposeFor(sender, proposer, requester, t, 42);
+
+        vm.startPrank(disputer);
+        currency.mint(disputer, 10_000 ether);
+        currency.approve(address(moo), type(uint256).max);
+        vm.expectRevert(ManagedOptimisticOracleV2Interface.SameBlockDisputeNotAllowed.selector);
+        moo.disputePrice(requester, IDENTIFIER, t, ANCILLARY);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 1);
+        _dispute(disputer, requester, t);
+        assertEq(
+            uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Disputed)
+        );
+    }
+
     // -------------------- Bond Range Management --------------------
 
     function testSetAllowedBondRangeValidations() external {
@@ -951,6 +971,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).proposalTime, proposalTime);
 
         // Dispute should result in Oracle price request with proposal timestamp
+        vm.warp(proposalTime + 1);
         vm.expectCall(
             address(oracle),
             abi.encodeWithSelector(


### PR DESCRIPTION
## What Changed

- Added a Managed OO-specific `SameBlockDisputeNotAllowed` custom error.
- Made `OptimisticOracleV2.disputePriceFor` virtual so Managed OO can add pre-dispute policy checks.
- Overrode `ManagedOptimisticOracleV2.disputePriceFor` to reject disputes when the stored proposal time equals the current block timestamp.
- Added unit coverage for same-block rejection and next-block dispute success.
- Updated Managed OO script docs to mention same-block dispute rejection.

## Why

- Automatic re-request callbacks need a strictly advanced timestamp for replacement requests.
- Allowing proposal and dispute in the same block can make callback-driven replacement requests collide with the active request timestamp.
- Managed OO should make the invalid same-block lifecycle impossible rather than relying on downstream callback behavior to recover.

## Impact

- Managed OO proposals can still be disputed normally starting in a later block timestamp.
- Expired proposals remain disputable under the existing Managed OO extended dispute-window behavior.
- Base `OptimisticOracleV2` runtime behavior is unchanged; its dispute function is only marked `virtual` for the Managed OO override.

## High risk Sections to review with detail

- `src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol`: the new `disputePriceFor` override preserves parent zero-disputer and state checks before applying the same-block guard.
- `src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol`: `disputePriceFor` is now virtual but otherwise unchanged.
- `test/ManagedOptimisticOracleV2.t.sol`: adjusted event-based dispute coverage to dispute one timestamp tick after proposal.

## Validation

- Ran `git diff --check`.
- Did not run builds or tests per instruction.
