### PR TITLE
refactor(pm-v2-oo-reporter)!: remove rerequest budgets

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -33,7 +33,7 @@ function getRequestResolution(bytes32 requestId) external view returns (int256);
 - requester/module allowlisting;
 - UMA oracle initializer allowlisting;
 - Managed OO request creation;
-- reward, bond, request-specific liveness bounds, automatic re-request controls, and manual re-request budget controls;
+- reward, bond, request-specific liveness bounds, and automatic re-request controls;
 - request rules update history for active requests;
 - raw UMA settlement storage.
 
@@ -48,24 +48,20 @@ The prediction market integration owns:
 An enabled requester first calls `registerRequest(...)` with its external `requestId`, UMA price identifier, raw request rules, and allowed liveness range. The reporter reserves the `(priceIdentifier, requestRules)` tuple globally so two request IDs cannot point at the same UMA request identity.
 
 An enabled UMA oracle initializer later calls `initializeRequest(requestId, reward, proposalBond, liveness)`. The selected
-liveness must be non-zero and inside the registered range. Each initialized request receives the current
-`defaultRerequestBudget` as its manual re-request budget.
+liveness must be non-zero and inside the registered range.
 
 Automatic re-requests are enabled by default and can be disabled or re-enabled by the owner with
 `setAutomaticRerequestsEnabled(...)`. The current setting is evaluated when a dispute or P4 settlement callback arrives,
 not when the request was initialized or last re-requested. When enabled, the first dispute callback for a request
-automatically creates one replacement request without consuming manual re-request budget. Later dispute callbacks open
-the manual re-request gate and emit `RequestRerequestAllowed`.
+automatically creates one replacement request. Later dispute callbacks open the manual re-request gate and emit
+`RequestRerequestAllowed`.
 
-P4 settlements reset the active request's manual budget to the current default. When automatic re-requests are enabled,
-P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are
+When automatic re-requests are enabled, P4 settlements create a replacement request. When automatic re-requests are
 disabled, P4 settlements open the manual re-request gate instead.
 
-The owner can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is open and manual
-budget remains. Manual re-requests can update the active reward, proposal bond, and liveness for the replacement request.
-Automatic re-requests reuse the active reward, proposal bond, and liveness. The owner can update the default budget for
-future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active unresolved request with
-`setRequestRerequestBudget(...)`.
+The owner can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is open. Manual
+re-requests can update the active reward, proposal bond, and liveness for the replacement request. Automatic re-requests
+reuse the active reward, proposal bond, and liveness.
 
 Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -57,8 +57,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         mapping(bytes32 reporterRequestKey => bytes32 requestId) requestIdsByReporterKey;
         /// @notice Mapping of requester-defined request ID to request rules update history.
         mapping(bytes32 requestId => RequestRulesUpdate[] updates) requestRulesUpdates;
-        /// @notice Default re-request budget seeded onto each request at initialization.
-        uint256 defaultRerequestBudget;
         /// @notice Whether first-dispute and P4 automatic re-requests are enabled.
         bool automaticRerequestsEnabled;
     }
@@ -107,8 +105,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         address _optimisticOracle,
         address _rewardCurrency,
         address initialOracleInitializer,
-        address initialRequester,
-        uint256 initialDefaultRerequestBudget
+        address initialRequester
     ) external initializer {
         if (initialOwner == address(0) || _optimisticOracle == address(0) || _rewardCurrency == address(0)) {
             revert AddressCannotBeZero();
@@ -128,9 +125,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             _setRequesterEnabled(initialRequester, true);
         }
 
-        $.defaultRerequestBudget = initialDefaultRerequestBudget;
         $.automaticRerequestsEnabled = true;
-        emit DefaultRerequestBudgetSet(initialDefaultRerequestBudget);
         emit AutomaticRerequestsEnabledSet(true);
     }
 
@@ -164,11 +159,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     /// @inheritdoc IOOReporter
-    function defaultRerequestBudget() public view returns (uint256) {
-        return _getStorage().defaultRerequestBudget;
-    }
-
-    /// @inheritdoc IOOReporter
     function automaticRerequestsEnabled() public view returns (bool) {
         return _getStorage().automaticRerequestsEnabled;
     }
@@ -181,14 +171,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     /// @inheritdoc IOOReporter
     function setOracleInitializerEnabled(address oracleInitializer, bool enabled) external onlyOwner {
         _setOracleInitializerEnabled(oracleInitializer, enabled);
-    }
-
-    /// @inheritdoc IOOReporter
-    function setDefaultRerequestBudget(uint256 newDefaultRerequestBudget) external onlyOwner {
-        if (defaultRerequestBudget() == newDefaultRerequestBudget) revert DefaultRerequestBudgetUnchanged();
-
-        _getStorage().defaultRerequestBudget = newDefaultRerequestBudget;
-        emit DefaultRerequestBudgetSet(newDefaultRerequestBudget);
     }
 
     /// @inheritdoc IOOReporter
@@ -267,14 +249,12 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         _requireValidRequestLiveness(request, liveness);
 
         uint256 requestTimestamp = block.timestamp;
-        uint256 manualRerequestsRemaining = defaultRerequestBudget();
         request.initialized = true;
         request.oracleInitializer = msg.sender;
         request.requestTimestamp = requestTimestamp;
         request.reward = reward;
         request.proposalBond = proposalBond;
         request.liveness = liveness;
-        request.manualRerequestsRemaining = manualRerequestsRemaining;
 
         _requestPrice(request.priceIdentifier, requestTimestamp, request.requestRules, reward, proposalBond, liveness);
 
@@ -287,8 +267,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             address(rewardCurrency()),
             reward,
             proposalBond,
-            liveness,
-            manualRerequestsRemaining
+            liveness
         );
     }
 
@@ -298,32 +277,11 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         if (!request.initialized) revert RequestNotInitialized();
         if (request.resolved) revert RequestAlreadyResolved();
         if (!request.rerequestAllowed) revert RequestRerequestNotAllowed();
-        if (request.manualRerequestsRemaining == 0) revert RequestRerequestBudgetExhausted();
         _requireValidRequestLiveness(request, liveness);
 
         uint256 previousRequestTimestamp = _executeRerequest(request, reward, proposalBond, liveness, msg.sender);
 
-        request.manualRerequestsRemaining -= 1;
-
         _emitRequestRerequested(requestId, request, previousRequestTimestamp, msg.sender, RerequestType.Manual);
-    }
-
-    /// @inheritdoc IOOReporter
-    function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external onlyOwner {
-        RequestData storage request = _requireRegistered(requestId);
-        if (!request.initialized) revert RequestNotInitialized();
-        if (request.resolved) revert RequestAlreadyResolved();
-        uint256 budgetCeiling = defaultRerequestBudget();
-        if (newManualRerequestsRemaining > budgetCeiling) {
-            revert RequestRerequestBudgetAboveDefault(newManualRerequestsRemaining, budgetCeiling);
-        }
-        if (request.manualRerequestsRemaining == newManualRerequestsRemaining) {
-            revert RequestRerequestBudgetUnchanged();
-        }
-
-        request.manualRerequestsRemaining = newManualRerequestsRemaining;
-
-        emit RequestRerequestBudgetSet(requestId, newManualRerequestsRemaining);
     }
 
     /// @notice Managed OO dispute callback. Auto re-requests once, then opens the owner re-request gate.
@@ -345,7 +303,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         }
     }
 
-    /// @notice Managed OO settlement callback. Stores final prices; resets the budget and re-requests on P4.
+    /// @notice Managed OO settlement callback. Stores final prices and re-requests on P4.
     /// @inheritdoc IOptimisticRequester
     function priceSettled(bytes32 identifier, uint256 timestamp, bytes memory requestRules, int256 price)
         external
@@ -358,12 +316,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         if (price == P4_PRICE) {
             // Reporter requests are event-based, so Managed OO rejects proposed P4; P4 here is DVM-resolved.
-            // Refill the manual budget so the owner can continue without intervention if automation is disabled.
-            uint256 budget = defaultRerequestBudget();
-            if (request.manualRerequestsRemaining != budget) {
-                request.manualRerequestsRemaining = budget;
-                emit RequestRerequestBudgetSet(requestId, budget);
-            }
             if (automaticRerequestsEnabled()) {
                 _executeAutomaticRerequest(requestId, request, RerequestType.AutomaticInvalidSettlement);
             } else {
@@ -476,10 +428,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         uint256 proposalBond,
         uint64 liveness,
         address oracleInitializer
-    )
-        private
-        returns (uint256 previousRequestTimestamp)
-    {
+    ) private returns (uint256 previousRequestTimestamp) {
         previousRequestTimestamp = request.requestTimestamp;
         uint256 requestTimestamp = block.timestamp;
         if (requestTimestamp <= previousRequestTimestamp) {
@@ -493,17 +442,10 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         request.oracleInitializer = oracleInitializer;
         request.rerequestAllowed = false;
 
-        _requestPrice(
-            request.priceIdentifier,
-            requestTimestamp,
-            request.requestRules,
-            reward,
-            proposalBond,
-            liveness
-        );
+        _requestPrice(request.priceIdentifier, requestTimestamp, request.requestRules, reward, proposalBond, liveness);
     }
 
-    /// @dev Creates a replacement request without spending manual budget.
+    /// @dev Creates a replacement request from a callback path.
     function _executeAutomaticRerequest(bytes32 requestId, RequestData storage request, RerequestType rerequestType)
         private
     {
@@ -529,8 +471,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             address(rewardCurrency()),
             request.reward,
             request.proposalBond,
-            request.liveness,
-            request.manualRerequestsRemaining
+            request.liveness
         );
     }
 

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -30,8 +30,6 @@ struct RequestData {
     bytes requestRules;
     /// @notice Final raw UMA outcome after settlement.
     int256 outcome;
-    /// @notice Remaining manual re-request budget. Seeded from the default at initialization and topped up by the owner.
-    uint256 manualRerequestsRemaining;
     /// @notice Minimum liveness UMA is allowed to use for this request.
     uint64 minimumLiveness;
     /// @notice Maximum liveness UMA is allowed to use for this request.
@@ -53,11 +51,11 @@ enum RerequestTrigger {
 }
 
 enum RerequestType {
-    /// @dev Owner-triggered re-request that consumes the manual re-request budget.
+    /// @dev Owner-triggered re-request.
     Manual,
-    /// @dev First-dispute automatic re-request that does not consume the manual re-request budget.
+    /// @dev First-dispute automatic re-request.
     AutomaticDispute,
-    /// @dev P4 settlement automatic re-request that does not consume the manual re-request budget.
+    /// @dev P4 settlement automatic re-request.
     AutomaticInvalidSettlement
 }
 
@@ -85,14 +83,8 @@ interface IOOReporter {
     error RequesterEnabledUnchanged();
     /// @notice Thrown when an oracle initializer allowlist update would not change state.
     error OracleInitializerEnabledUnchanged();
-    /// @notice Thrown when a default re-request budget update would not change state.
-    error DefaultRerequestBudgetUnchanged();
     /// @notice Thrown when an automatic re-request setting update would not change state.
     error AutomaticRerequestsEnabledUnchanged();
-    /// @notice Thrown when a per-request re-request budget update would not change state.
-    error RequestRerequestBudgetUnchanged();
-    /// @notice Thrown when a per-request re-request budget top-up exceeds the contract-level default budget.
-    error RequestRerequestBudgetAboveDefault(uint256 requested, uint256 defaultRerequestBudget);
     /// @notice Thrown when creating an OO request for an already initialized request.
     error RequestAlreadyInitialized();
     /// @notice Thrown when registering a request ID that has already been registered.
@@ -109,8 +101,6 @@ interface IOOReporter {
     error RequestRerequestNotAllowed();
     /// @notice Thrown when a replacement request timestamp does not advance.
     error RequestRerequestTimestampNotAdvanced(uint256 currentTimestamp, uint256 previousRequestTimestamp);
-    /// @notice Thrown when the manual re-request budget is exhausted.
-    error RequestRerequestBudgetExhausted();
     /// @notice Thrown when raw request rules is empty or too large for the OO.
     error InvalidRequestRules();
     /// @notice Thrown when minimum liveness is greater than maximum liveness.
@@ -140,8 +130,6 @@ interface IOOReporter {
     event RequesterEnabledSet(address indexed requester, bool enabled);
     /// @notice Emitted when the owner enables or disables a UMA oracle initializer.
     event OracleInitializerEnabledSet(address indexed oracleInitializer, bool enabled);
-    /// @notice Emitted when the owner updates the default per-request re-request budget.
-    event DefaultRerequestBudgetSet(uint256 defaultRerequestBudget);
     /// @notice Emitted when the owner enables or disables automatic re-requests.
     event AutomaticRerequestsEnabledSet(bool enabled);
     /// @notice Emitted when an approved requester registers a request for UMA initialization.
@@ -163,8 +151,7 @@ interface IOOReporter {
         address rewardCurrency,
         uint256 reward,
         uint256 proposalBond,
-        uint64 liveness,
-        uint256 manualRerequestsRemaining
+        uint64 liveness
     );
     /// @notice Emitted when the registering requester posts updated request rules for offchain consumers.
     event RequestRulesUpdated(
@@ -186,11 +173,8 @@ interface IOOReporter {
         address rewardCurrency,
         uint256 reward,
         uint256 proposalBond,
-        uint64 liveness,
-        uint256 manualRerequestsRemaining
+        uint64 liveness
     );
-    /// @notice Emitted when the owner updates the remaining re-request budget for one request.
-    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 manualRerequestsRemaining);
     /// @notice Emitted when the owner sweeps ERC20 or native token funds from the reporter.
     event FundsSwept(address indexed token, address indexed recipient, uint256 amount);
     /// @notice Emitted when the owner claims a deferred Managed OO payout owed to the reporter.
@@ -201,19 +185,17 @@ interface IOOReporter {
     --------------------------------------------------------------*/
 
     /// @notice Initializes the upgradeable reporter.
-    /// @param initialOwner Owner that can manage requesters, oracle initializers, budgets, and upgrades.
+    /// @param initialOwner Owner that can manage requesters, oracle initializers, automation, and upgrades.
     /// @param optimisticOracle Managed Optimistic Oracle V2 address.
     /// @param rewardCurrency ERC20 reward currency used for all reporter-created OO requests.
     /// @param initialOracleInitializer Optional first UMA oracle initializer; pass zero to set later.
     /// @param initialRequester Optional first requester; pass zero to set later.
-    /// @param initialDefaultRerequestBudget Default replacement-request budget seeded onto each initialized request.
     function initialize(
         address initialOwner,
         address optimisticOracle,
         address rewardCurrency,
         address initialOracleInitializer,
-        address initialRequester,
-        uint256 initialDefaultRerequestBudget
+        address initialRequester
     ) external;
 
     /// @notice Enables or disables an address allowed to register requests.
@@ -225,10 +207,6 @@ interface IOOReporter {
     /// @param oracleInitializer Oracle initializer address to update.
     /// @param enabled Whether oracleInitializer should be enabled.
     function setOracleInitializerEnabled(address oracleInitializer, bool enabled) external;
-
-    /// @notice Updates the default replacement-request budget for future initialized requests.
-    /// @param newDefaultRerequestBudget New default re-request budget.
-    function setDefaultRerequestBudget(uint256 newDefaultRerequestBudget) external;
 
     /// @notice Enables or disables automatic dispute and P4 re-requests.
     /// @param enabled Whether automatic re-requests should be enabled.
@@ -243,10 +221,6 @@ interface IOOReporter {
     /// @param candidate Address to check.
     /// @return True if candidate is an enabled UMA oracle initializer.
     function isOracleInitializer(address candidate) external view returns (bool);
-
-    /// @notice Returns the default replacement-request budget seeded onto each initialized request.
-    /// @return Current default re-request budget.
-    function defaultRerequestBudget() external view returns (uint256);
 
     /// @notice Returns whether automatic dispute and P4 re-requests are enabled.
     /// @return True if automatic re-requests are enabled.
@@ -287,11 +261,6 @@ interface IOOReporter {
     /// @param proposalBond Bond required from OO proposers/disputers, or zero to use the OO default.
     /// @param liveness Custom OO liveness period within the registered bounds.
     function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
-
-    /// @notice Updates the remaining re-request budget for an initialized unresolved request.
-    /// @param requestId Registered request ID.
-    /// @param newManualRerequestsRemaining New remaining manual re-request budget, capped by the current default.
-    function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external;
 
     /// @notice Returns whether a final reporter outcome is available for requestId.
     /// @param requestId Registered request ID.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -82,11 +82,8 @@ contract OOReporterTest {
         address rewardCurrency,
         uint256 reward,
         uint256 proposalBond,
-        uint64 liveness,
-        uint256 manualRerequestsRemaining
+        uint64 liveness
     );
-    event RequestRerequestBudgetSet(bytes32 indexed requestId, uint256 manualRerequestsRemaining);
-    event DefaultRerequestBudgetSet(uint256 defaultRerequestBudget);
     event AutomaticRerequestsEnabledSet(bool enabled);
 
     bytes32 internal constant REQUEST_ID = keccak256("request-id");
@@ -99,7 +96,6 @@ contract OOReporterTest {
     uint256 internal constant MANUAL_PROPOSAL_BOND = 700_000_000;
     uint64 internal constant LIVENESS = 7200;
     uint64 internal constant MANUAL_LIVENESS = 3 hours;
-    uint256 internal constant DEFAULT_REREQUEST_BUDGET = 10;
     uint64 internal constant MINIMUM_LIVENESS = 0;
     uint64 internal constant MAXIMUM_LIVENESS = 2 days;
     uint64 internal constant STRICT_MINIMUM_LIVENESS = 1 hours;
@@ -121,8 +117,7 @@ contract OOReporterTest {
 
         OOReporter implementation = new OOReporter();
         bytes memory initData = abi.encodeCall(
-            IOOReporter.initialize,
-            (owner, address(optimisticOracle), address(usdc), oracleInitializer, requester, DEFAULT_REREQUEST_BUDGET)
+            IOOReporter.initialize, (owner, address(optimisticOracle), address(usdc), oracleInitializer, requester)
         );
         reporter = OOReporter(address(new SimpleProxy(address(implementation), initData)));
     }
@@ -248,7 +243,7 @@ contract OOReporterTest {
         reporter.registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules, MINIMUM_LIVENESS, belowOracleMinimum);
     }
 
-    function test_initializeRequestSeedsDefaultBudgetAndCreatesManagedOORequest() external {
+    function test_initializeRequestCreatesManagedOORequest() external {
         bytes memory requestRules = _requestRules("numerical");
         _registerRequest(REQUEST_ID, NUMERICAL_IDENTIFIER, requestRules);
         usdc.mint(address(reporter), REWARD);
@@ -265,9 +260,6 @@ contract OOReporterTest {
         assertEq(request.liveness, LIVENESS, "liveness mismatch");
         assertEq(request.minimumLiveness, MINIMUM_LIVENESS, "minimum liveness mismatch");
         assertEq(request.maximumLiveness, MAXIMUM_LIVENESS, "maximum liveness mismatch");
-        assertEq(
-            request.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "re-request budget should seed from default"
-        );
         assertFalse(request.automaticDisputeRerequestUsed, "automatic dispute re-request should start unused");
         assertTrue(reporter.automaticRerequestsEnabled(), "automatic re-requests should initialize enabled");
 
@@ -464,7 +456,7 @@ contract OOReporterTest {
         );
     }
 
-    function test_priceDisputedAutomaticallyRerequestsOnceWithoutConsumingBudget() external {
+    function test_priceDisputedAutomaticallyRerequestsOnce() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
@@ -484,8 +476,7 @@ contract OOReporterTest {
             address(usdc),
             0,
             PROPOSAL_BOND,
-            LIVENESS,
-            DEFAULT_REREQUEST_BUDGET
+            LIVENESS
         );
 
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
@@ -495,7 +486,6 @@ contract OOReporterTest {
         assertFalse(afterAuto.resolved, "dispute should not resolve the request");
         assertTrue(afterAuto.automaticDisputeRerequestUsed, "automatic dispute re-request should be marked used");
         assertEq(afterAuto.requestTimestamp, block.timestamp, "automatic dispute should advance timestamp");
-        assertEq(afterAuto.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "dispute should not consume budget");
     }
 
     function test_priceDisputedOpensManualGateAfterAutomaticDisputeUsed() external {
@@ -520,8 +510,9 @@ contract OOReporterTest {
         RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
         assertTrue(allowedRequest.rerequestAllowed, "second dispute should open the manual gate");
         assertTrue(allowedRequest.automaticDisputeRerequestUsed, "automatic dispute re-request should stay used");
-        assertEq(allowedRequest.requestTimestamp, afterAuto.requestTimestamp, "manual gate should not advance timestamp");
-        assertEq(allowedRequest.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "gate should not consume budget");
+        assertEq(
+            allowedRequest.requestTimestamp, afterAuto.requestTimestamp, "manual gate should not advance timestamp"
+        );
     }
 
     function test_priceDisputedUsesCurrentAutomationSettingAfterDisabledFirstDispute() external {
@@ -574,8 +565,7 @@ contract OOReporterTest {
             address(usdc),
             0,
             PROPOSAL_BOND,
-            LIVENESS,
-            DEFAULT_REREQUEST_BUDGET - 1
+            LIVENESS
         );
 
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, afterManual.requestTimestamp, requestRules);
@@ -584,14 +574,9 @@ contract OOReporterTest {
         assertFalse(afterAuto.rerequestAllowed, "enabled later dispute should auto re-request");
         assertTrue(afterAuto.automaticDisputeRerequestUsed, "enabled later dispute should consume automatic slot");
         assertEq(afterAuto.requestTimestamp, block.timestamp, "enabled later dispute should advance timestamp");
-        assertEq(
-            afterAuto.manualRerequestsRemaining,
-            DEFAULT_REREQUEST_BUDGET - 1,
-            "automatic re-request should not consume budget"
-        );
     }
 
-    function test_priceSettledP4ResetsBudgetAndAutomaticallyRerequests() external {
+    function test_priceSettledP4AutomaticallyRerequests() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
@@ -601,7 +586,7 @@ contract OOReporterTest {
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
-        // Spend one manual re-request so we can prove P4 refills the manual budget to the default.
+        // Use one manual re-request so we can prove P4 preserves the latest active bond/liveness.
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
@@ -609,14 +594,11 @@ contract OOReporterTest {
         reporter.rerequest(REQUEST_ID, 0, MANUAL_PROPOSAL_BOND, MANUAL_LIVENESS);
 
         RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
-        assertEq(afterManual.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement once");
 
         vm.prank(owner);
         reporter.setAutomaticRerequestsEnabled(true);
         vm.warp(block.timestamp + 1);
 
-        vm.expectEmit(address(reporter));
-        emit RequestRerequestBudgetSet(REQUEST_ID, DEFAULT_REREQUEST_BUDGET);
         vm.expectEmit(address(reporter));
         emit RequestRerequested(
             REQUEST_ID,
@@ -627,8 +609,7 @@ contract OOReporterTest {
             address(usdc),
             0,
             MANUAL_PROPOSAL_BOND,
-            MANUAL_LIVENESS,
-            DEFAULT_REREQUEST_BUDGET
+            MANUAL_LIVENESS
         );
 
         optimisticOracle.settle(
@@ -639,7 +620,6 @@ contract OOReporterTest {
         assertFalse(afterP4.resolved, "P4 should not resolve request");
         assertFalse(reporter.isRequestResolved(REQUEST_ID), "P4 should not resolve request");
         assertFalse(afterP4.rerequestAllowed, "automatic P4 re-request should not leave gate open");
-        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default");
         assertEq(afterP4.requestTimestamp, block.timestamp, "P4 should auto re-request");
         assertEq(afterP4.proposalBond, MANUAL_PROPOSAL_BOND, "P4 should preserve latest manual bond");
         assertEq(afterP4.liveness, MANUAL_LIVENESS, "P4 should preserve latest manual liveness");
@@ -670,8 +650,9 @@ contract OOReporterTest {
 
         RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
         assertTrue(afterP4.rerequestAllowed, "disabled P4 automation should open manual gate");
-        assertEq(afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp");
-        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available");
+        assertEq(
+            afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp"
+        );
     }
 
     function test_priceSettledP4UsesCurrentAutomationSettingAfterBeingDisabled() external {
@@ -700,12 +681,9 @@ contract OOReporterTest {
         assertEq(
             afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 callback should not advance timestamp"
         );
-        assertEq(
-            afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "disabled P4 should leave budget available"
-        );
     }
 
-    function test_rerequestConsumesBudgetAndCreatesReplacementRequest() external {
+    function test_rerequestCreatesReplacementRequest() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
@@ -732,8 +710,7 @@ contract OOReporterTest {
             address(usdc),
             REREQUEST_REWARD,
             MANUAL_PROPOSAL_BOND,
-            MANUAL_LIVENESS,
-            DEFAULT_REREQUEST_BUDGET - 1
+            MANUAL_LIVENESS
         );
 
         vm.prank(owner);
@@ -744,7 +721,6 @@ contract OOReporterTest {
         assertEq(rerequested.reward, REREQUEST_REWARD, "re-request reward mismatch");
         assertEq(rerequested.proposalBond, MANUAL_PROPOSAL_BOND, "re-request bond mismatch");
         assertEq(rerequested.liveness, MANUAL_LIVENESS, "re-request liveness mismatch");
-        assertEq(rerequested.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET - 1, "budget should decrement");
         assertFalse(rerequested.rerequestAllowed, "gate should close after re-request");
 
         bytes32 requestKey =
@@ -798,107 +774,6 @@ contract OOReporterTest {
             )
         );
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, STRICT_MAXIMUM_LIVENESS + 1);
-    }
-
-    function test_rerequestBudgetExhaustsAndOwnerCanTopUp() external {
-        bytes memory requestRules = _requestRules("primary");
-        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
-
-        // Seed a small budget so it can be exhausted in a couple of re-requests.
-        vm.prank(owner);
-        reporter.setDefaultRerequestBudget(2);
-        vm.prank(owner);
-        reporter.setAutomaticRerequestsEnabled(false);
-
-        vm.prank(oracleInitializer);
-        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
-
-        // Consume the full budget, reopening the gate before each re-request.
-        _disputeAndRerequest(requestRules);
-        _disputeAndRerequest(requestRules);
-
-        // Budget exhausted: gate is open again, but the re-request must revert.
-        RequestData memory exhausted = reporter.getRequest(REQUEST_ID);
-        assertEq(exhausted.manualRerequestsRemaining, 0, "budget should be exhausted");
-        vm.warp(block.timestamp + 1);
-        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, exhausted.requestTimestamp, requestRules);
-
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestRerequestBudgetExhausted.selector);
-        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
-
-        // Owner cannot top a request up beyond the contract-level default budget.
-        vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IOOReporter.RequestRerequestBudgetAboveDefault.selector, 3, 2));
-        reporter.setRequestRerequestBudget(REQUEST_ID, 3);
-
-        // Owner tops the budget back up to the default ceiling and re-requests succeed again.
-        vm.expectEmit(address(reporter));
-        emit RequestRerequestBudgetSet(REQUEST_ID, 2);
-        vm.prank(owner);
-        reporter.setRequestRerequestBudget(REQUEST_ID, 2);
-
-        vm.prank(owner);
-        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
-
-        assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 1, "budget should reflect top-up minus one");
-    }
-
-    function test_setRequestRerequestBudgetRejectsUnauthorizedUnchangedAndResolved() external {
-        bytes memory requestRules = _requestRules("primary");
-        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
-
-        // Cannot set budget before initialization.
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestNotInitialized.selector);
-        reporter.setRequestRerequestBudget(REQUEST_ID, 5);
-
-        vm.prank(oracleInitializer);
-        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
-
-        vm.prank(unauthorized);
-        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("OwnableUnauthorizedAccount(address)")), unauthorized));
-        reporter.setRequestRerequestBudget(REQUEST_ID, 5);
-
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestRerequestBudgetUnchanged.selector);
-        reporter.setRequestRerequestBudget(REQUEST_ID, DEFAULT_REREQUEST_BUDGET);
-
-        // Owner cannot top a request up beyond the contract-level default budget.
-        vm.prank(owner);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IOOReporter.RequestRerequestBudgetAboveDefault.selector,
-                DEFAULT_REREQUEST_BUDGET + 1,
-                DEFAULT_REREQUEST_BUDGET
-            )
-        );
-        reporter.setRequestRerequestBudget(REQUEST_ID, DEFAULT_REREQUEST_BUDGET + 1);
-
-        RequestData memory request = reporter.getRequest(REQUEST_ID);
-        optimisticOracle.settle(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, 1 ether);
-
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
-        reporter.setRequestRerequestBudget(REQUEST_ID, 5);
-    }
-
-    function test_setDefaultRerequestBudgetUpdatesFutureInitializations() external {
-        vm.expectEmit(address(reporter));
-        emit DefaultRerequestBudgetSet(4);
-        vm.prank(owner);
-        reporter.setDefaultRerequestBudget(4);
-        assertEq(reporter.defaultRerequestBudget(), 4, "default budget should update");
-
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.DefaultRerequestBudgetUnchanged.selector);
-        reporter.setDefaultRerequestBudget(4);
-
-        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, _requestRules("primary"));
-        vm.prank(oracleInitializer);
-        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
-
-        assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 4, "request should seed new default budget");
     }
 
     function test_setAutomaticRerequestsEnabledUpdatesAndRejectsInvalidChanges() external {
@@ -961,7 +836,7 @@ contract OOReporterTest {
         assertEq(updatedRequest.requestTimestamp, activeRequest.requestTimestamp, "active timestamp changed");
     }
 
-    function test_resolvedRequestsCannotBeRerequestedOrBudgetSet() external {
+    function test_resolvedRequestsCannotBeRerequested() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
 
@@ -974,10 +849,6 @@ contract OOReporterTest {
         vm.prank(owner);
         vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
         reporter.rerequest(REQUEST_ID, REREQUEST_REWARD, PROPOSAL_BOND, LIVENESS);
-
-        vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
-        reporter.setRequestRerequestBudget(REQUEST_ID, 5);
     }
 
     function _disputeAndRerequest(bytes memory requestRules) internal {


### PR DESCRIPTION
## What Changed

- Removed the manual re-request budget from `RequestData`, `RequestInitialized`, and `RequestRerequested`.
- Removed the default re-request budget API: `defaultRerequestBudget()` and `setDefaultRerequestBudget(...)`.
- Removed per-request budget mutation: `setRequestRerequestBudget(...)` and budget-related errors/events.
- Kept owner-gated `rerequest(...)` behavior behind the existing callback-opened gate, without a per-request counter.
- Updated OOReporter tests and README lifecycle docs to match the simplified rerequest model.

## Why

Manual rerequests are already owner-gated after a callback opens the manual gate, so the per-request budget was redundant as an owner self-rate-limit. Removing it makes the UMA-side reporter interface smaller before audit while preserving automatic first-dispute/P4 rerequest behavior.

## Impact

This is an ABI/event/storage-shape change for the unaudited PM v2 reporter package.

Polymarket's current `OOReporterModule` integration does not depend on the removed budget surface in production. The module only calls the narrow reporter boundary it needs for request registration, rule updates, and result reads:

- `registerRequest(...)`
- `updateRequestRules(...)`
- `isRequestResolved(...)`
- `getRequestResolution(...)`

Those production calls are unchanged by this PR, so Polymarket does not need to bump `lib/managed-oracle` just for this cleanup.

If Polymarket intentionally bumps the managed-oracle submodule to consume UMA-side audit fixes after this PR, their source tree will need small compile/test-harness updates because it imports and mocks the full `IOOReporter` surface. Expected follow-up there:

- update `MockOOReporter` to remove `defaultRerequestBudget()` and `setRequestRerequestBudget(...)` stubs;
- update real-reporter integration setup to use the shorter `initialize(...)` signature;
- remove assertions against `RequestData.manualRerequestsRemaining`, keeping assertions for timestamp advancement, automatic-dispute usage, and active reward/bond/liveness preservation.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol`
- `cd pm-v2-oo-reporter && forge build`
- `cd pm-v2-oo-reporter && forge test`
- `git diff --check`