### PR TITLE
fix(pm-v2-oo-reporter): gate manual rerequests by initializer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,40 @@ jobs:
           forge test -vvv --no-match-contract ".*Fork.*"
         id: test
 
+  pm-v2-oo-reporter:
+    name: PM v2 OOReporter package
+    runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: default
+    defaults:
+      run:
+        working-directory: pm-v2-oo-reporter
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+
+      - name: Show Forge version
+        run: |
+          forge --version
+
+      - name: Run Forge fmt
+        run: |
+          forge fmt --check
+
+      - name: Run Forge build
+        run: |
+          forge build
+
+      - name: Run Forge tests
+        run: |
+          forge test
+
   fork-tests:
     name: Fork Tests (Polygon)
     runs-on: ubuntu-latest

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -61,11 +61,11 @@ P4 settlements reset the active request's manual budget to the current default. 
 P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are
 disabled, P4 settlements open the manual re-request gate instead.
 
-The owner can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is open and manual
-budget remains. Manual re-requests can update the active reward, proposal bond, and liveness for the replacement request.
-Automatic re-requests reuse the active reward, proposal bond, and liveness. The owner can update the default budget for
-future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active unresolved request with
-`setRequestRerequestBudget(...)`.
+An enabled oracle initializer can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is
+open and manual budget remains. Manual re-requests can update the active reward, proposal bond, and liveness for the
+replacement request. Automatic re-requests reuse the active reward, proposal bond, and liveness. The owner can update
+the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active
+unresolved request with `setRequestRerequestBudget(...)`.
 
 Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -293,7 +293,10 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     /// @inheritdoc IOOReporter
-    function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external onlyOwner {
+    function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness)
+        external
+        onlyOracleInitializer
+    {
         RequestData storage request = _requireRegistered(requestId);
         if (!request.initialized) revert RequestNotInitialized();
         if (request.resolved) revert RequestAlreadyResolved();
@@ -326,7 +329,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         emit RequestRerequestBudgetSet(requestId, newManualRerequestsRemaining);
     }
 
-    /// @notice Managed OO dispute callback. Auto re-requests once, then opens the owner re-request gate.
+    /// @notice Managed OO dispute callback. Auto re-requests once, then opens the oracle-initializer re-request gate.
     /// @inheritdoc IOptimisticRequester
     function priceDisputed(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256)
         external
@@ -476,10 +479,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         uint256 proposalBond,
         uint64 liveness,
         address oracleInitializer
-    )
-        private
-        returns (uint256 previousRequestTimestamp)
-    {
+    ) private returns (uint256 previousRequestTimestamp) {
         previousRequestTimestamp = request.requestTimestamp;
         uint256 requestTimestamp = block.timestamp;
         if (requestTimestamp <= previousRequestTimestamp) {
@@ -493,14 +493,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         request.oracleInitializer = oracleInitializer;
         request.rerequestAllowed = false;
 
-        _requestPrice(
-            request.priceIdentifier,
-            requestTimestamp,
-            request.requestRules,
-            reward,
-            proposalBond,
-            liveness
-        );
+        _requestPrice(request.priceIdentifier, requestTimestamp, request.requestRules, reward, proposalBond, liveness);
     }
 
     /// @dev Creates a replacement request without spending manual budget.

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -361,7 +361,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         if (price == P4_PRICE) {
             // Reporter requests are event-based, so Managed OO rejects proposed P4; P4 here is DVM-resolved.
-            // Refill the manual budget so the owner can continue without intervention if automation is disabled.
+            // Refill the manual budget so an enabled oracle initializer can continue without owner intervention if
+            // automation is disabled.
             uint256 budget = defaultRerequestBudget();
             if (request.manualRerequestsRemaining != budget) {
                 request.manualRerequestsRemaining = budget;

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -53,7 +53,7 @@ enum RerequestTrigger {
 }
 
 enum RerequestType {
-    /// @dev Owner-triggered re-request that consumes the manual re-request budget.
+    /// @dev Oracle-initializer-triggered re-request that consumes the manual re-request budget.
     Manual,
     /// @dev First-dispute automatic re-request that does not consume the manual re-request budget.
     AutomaticDispute,
@@ -172,7 +172,7 @@ interface IOOReporter {
     );
     /// @notice Emitted when a final raw UMA outcome is stored for a request.
     event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
-    /// @notice Emitted when a callback opens the owner re-request path.
+    /// @notice Emitted when a callback opens the oracle-initializer re-request path.
     event RequestRerequestAllowed(
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
     );

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -281,7 +281,7 @@ interface IOOReporter {
     /// @param liveness Custom OO liveness period within the registered bounds.
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
-    /// @notice Allows the owner to create a replacement Managed OO request after a callback opens the gate.
+    /// @notice Allows an enabled oracle initializer to create a replacement Managed OO request after a callback opens the gate.
     /// @param requestId Registered request ID.
     /// @param reward Reward amount for the replacement request.
     /// @param proposalBond Bond required from OO proposers/disputers, or zero to use the OO default.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -520,7 +520,9 @@ contract OOReporterTest {
         RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
         assertTrue(allowedRequest.rerequestAllowed, "second dispute should open the manual gate");
         assertTrue(allowedRequest.automaticDisputeRerequestUsed, "automatic dispute re-request should stay used");
-        assertEq(allowedRequest.requestTimestamp, afterAuto.requestTimestamp, "manual gate should not advance timestamp");
+        assertEq(
+            allowedRequest.requestTimestamp, afterAuto.requestTimestamp, "manual gate should not advance timestamp"
+        );
         assertEq(allowedRequest.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "gate should not consume budget");
     }
 
@@ -555,7 +557,7 @@ contract OOReporterTest {
         );
 
         vm.warp(block.timestamp + 1);
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
@@ -605,7 +607,7 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         reporter.rerequest(REQUEST_ID, 0, MANUAL_PROPOSAL_BOND, MANUAL_LIVENESS);
 
         RequestData memory afterManual = reporter.getRequest(REQUEST_ID);
@@ -639,7 +641,9 @@ contract OOReporterTest {
         assertFalse(afterP4.resolved, "P4 should not resolve request");
         assertFalse(reporter.isRequestResolved(REQUEST_ID), "P4 should not resolve request");
         assertFalse(afterP4.rerequestAllowed, "automatic P4 re-request should not leave gate open");
-        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default");
+        assertEq(
+            afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should refill the budget to the default"
+        );
         assertEq(afterP4.requestTimestamp, block.timestamp, "P4 should auto re-request");
         assertEq(afterP4.proposalBond, MANUAL_PROPOSAL_BOND, "P4 should preserve latest manual bond");
         assertEq(afterP4.liveness, MANUAL_LIVENESS, "P4 should preserve latest manual liveness");
@@ -670,8 +674,12 @@ contract OOReporterTest {
 
         RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
         assertTrue(afterP4.rerequestAllowed, "disabled P4 automation should open manual gate");
-        assertEq(afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp");
-        assertEq(afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available");
+        assertEq(
+            afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp"
+        );
+        assertEq(
+            afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available"
+        );
     }
 
     function test_priceSettledP4UsesCurrentAutomationSettingAfterBeingDisabled() external {
@@ -726,7 +734,7 @@ contract OOReporterTest {
         emit RequestRerequested(
             REQUEST_ID,
             block.timestamp,
-            owner,
+            oracleInitializer,
             RerequestType.Manual,
             afterAuto.requestTimestamp,
             address(usdc),
@@ -736,7 +744,7 @@ contract OOReporterTest {
             DEFAULT_REREQUEST_BUDGET - 1
         );
 
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         reporter.rerequest(REQUEST_ID, REREQUEST_REWARD, MANUAL_PROPOSAL_BOND, MANUAL_LIVENESS);
 
         RequestData memory rerequested = reporter.getRequest(REQUEST_ID);
@@ -762,13 +770,23 @@ contract OOReporterTest {
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
-        vm.prank(unauthorized);
-        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("OwnableUnauthorizedAccount(address)")), unauthorized));
+        vm.prank(oracleInitializer);
+        vm.expectRevert(IOOReporter.RequestRerequestNotAllowed.selector);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
-        vm.warp(block.timestamp + 1);
         vm.prank(owner);
-        vm.expectRevert(IOOReporter.RequestRerequestNotAllowed.selector);
+        reporter.setAutomaticRerequestsEnabled(false);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        vm.prank(owner);
+        vm.expectRevert(IOOReporter.CallerNotOracleInitializer.selector);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        vm.prank(unauthorized);
+        vm.expectRevert(IOOReporter.CallerNotOracleInitializer.selector);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
     }
 
@@ -788,7 +806,7 @@ contract OOReporterTest {
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
 
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IOOReporter.RequestLivenessOutOfRange.selector,
@@ -823,7 +841,7 @@ contract OOReporterTest {
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, exhausted.requestTimestamp, requestRules);
 
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         vm.expectRevert(IOOReporter.RequestRerequestBudgetExhausted.selector);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
@@ -838,7 +856,7 @@ contract OOReporterTest {
         vm.prank(owner);
         reporter.setRequestRerequestBudget(REQUEST_ID, 2);
 
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         assertEq(reporter.getRequest(REQUEST_ID).manualRerequestsRemaining, 1, "budget should reflect top-up minus one");
@@ -971,7 +989,7 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         optimisticOracle.settle(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, 1 ether);
 
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
         reporter.rerequest(REQUEST_ID, REREQUEST_REWARD, PROPOSAL_BOND, LIVENESS);
 
@@ -984,7 +1002,7 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
         optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
-        vm.prank(owner);
+        vm.prank(oracleInitializer);
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
     }
 


### PR DESCRIPTION
## What Changed

- Restored `rerequest(...)` to the oracle-initializer gate instead of the owner gate.
- Kept owner-controlled budget and automation settings unchanged.
- Updated OOReporter docs, NatSpec wording, and tests so manual re-requests are performed by an enabled oracle initializer.
- Added a dedicated CI job for the nested `pm-v2-oo-reporter` Foundry package, pinned separately to Forge `v1.7.1`.

## Why

The automatic re-request changes accidentally made manual re-requests owner-gated. That is the wrong operational boundary: the manual re-request caller should be the enabled UMA oracle initializer hot-wallet path, while the owner continues to control configuration such as initializer allowlisting, default budgets, per-request budget top-ups, automation toggles, upgrades, and fund recovery.

The root Foundry CI intentionally remains pinned to Forge `v1.3.6` for the existing root contracts. Because `pm-v2-oo-reporter` is a nested Foundry project with its own dependency/compiler context, root CI does not enter the package and did not catch package formatting drift. This PR adds a package-scoped job that runs from `pm-v2-oo-reporter/`.

## Impact

This is a behavior fix only. It does not change the ABI, event signatures, or storage layout.

Polymarket's current `OOReporterModule` production integration remains unaffected because it does not call `rerequest(...)`; it only uses the registration/update/read boundary:

- `registerRequest(...)`
- `updateRequestRules(...)`
- `isRequestResolved(...)`
- `getRequestResolution(...)`

The practical effect is limited to UMA-side OOReporter operations: once a dispute or disabled P4 path opens the manual gate, an enabled oracle initializer can execute the replacement request without requiring owner-key access, and the existing manual re-request budget still limits that path.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge build`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol`
- `cd pm-v2-oo-reporter && forge test`
- `git diff --check`