### PR TITLE
fix[ai-scan-h-01]: keep auto rerequest callbacks nonblocking

### DIFF
--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -340,7 +340,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             _loadCallbackRequest(identifier, timestamp, requestRules);
         if (shouldIgnore || request.resolved) return;
 
-        if (automaticRerequestsEnabled() && !request.automaticDisputeRerequestUsed) {
+        if (!request.automaticDisputeRerequestUsed && _canExecuteAutomaticRerequest(request)) {
             request.automaticDisputeRerequestUsed = true;
             _executeAutomaticRerequest(requestId, request, RerequestType.AutomaticDispute);
         } else {
@@ -368,7 +368,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
                 request.manualRerequestsRemaining = budget;
                 emit RequestRerequestBudgetSet(requestId, budget);
             }
-            if (automaticRerequestsEnabled()) {
+            if (_canExecuteAutomaticRerequest(request)) {
                 _executeAutomaticRerequest(requestId, request, RerequestType.AutomaticInvalidSettlement);
             } else {
                 _allowRerequest(requestId, timestamp, request, RerequestTrigger.InvalidSettlement);
@@ -506,6 +506,15 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         _emitRequestRerequested(requestId, request, previousRequestTimestamp, address(this), rerequestType);
     }
 
+    /// @dev Prechecks expected local automatic re-request blockers so callbacks can open the manual path without
+    /// reverting. Unexpected oracle, token, or config failures inside `_requestPrice` still revert instead of being
+    /// hidden behind a manual fallback.
+    function _canExecuteAutomaticRerequest(RequestData storage request) private view returns (bool) {
+        if (!automaticRerequestsEnabled()) return false;
+        if (block.timestamp <= request.requestTimestamp) return false;
+        return request.reward == 0 || rewardCurrency().balanceOf(address(this)) >= request.reward;
+    }
+
     /// @dev Emits the post-state for a replacement Managed OO request.
     function _emitRequestRerequested(
         bytes32 requestId,
@@ -554,7 +563,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             oracle.setBond(priceIdentifier, requestTimestamp, requestRules, proposalBond);
         }
 
-        // This can still fail if oracle liveness config changed since the bounds were registered.
+        // Unexpected Managed OO config drift should surface instead of silently opening the manual gate.
+        // For example, this can fail if oracle liveness config changed since the bounds were registered.
         oracle.setCustomLiveness(priceIdentifier, requestTimestamp, requestRules, liveness);
     }
 

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -506,9 +506,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         _emitRequestRerequested(requestId, request, previousRequestTimestamp, address(this), rerequestType);
     }
 
-    /// @dev Prechecks expected local automatic re-request blockers so callbacks can open the manual path without
-    /// reverting. Unexpected oracle, token, or config failures inside `_requestPrice` still revert instead of being
-    /// hidden behind a manual fallback.
+    /// @dev Handles expected local blockers only. Managed OO config failures still revert; reporter deprecation should
+    /// disable automation before de-whitelisting.
     function _canExecuteAutomaticRerequest(RequestData storage request) private view returns (bool) {
         if (!automaticRerequestsEnabled()) return false;
         if (block.timestamp <= request.requestTimestamp) return false;

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -526,6 +526,61 @@ contract OOReporterTest {
         assertEq(allowedRequest.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "gate should not consume budget");
     }
 
+    function test_priceDisputedOpensManualGateWhenAutomaticRerequestTimestampNotAdvanced() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.Dispute);
+
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
+        assertTrue(allowedRequest.rerequestAllowed, "same-block dispute should open manual gate");
+        assertFalse(
+            allowedRequest.automaticDisputeRerequestUsed, "blocked automatic dispute should not consume automatic slot"
+        );
+        assertEq(
+            allowedRequest.requestTimestamp,
+            request.requestTimestamp,
+            "blocked automatic dispute should not advance timestamp"
+        );
+    }
+
+    function test_priceDisputedOpensManualGateWhenRefundDeferred() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        usdc.mint(address(reporter), REWARD);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.setDeferNextDisputeRefund(true);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.Dispute);
+
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory allowedRequest = reporter.getRequest(REQUEST_ID);
+        assertTrue(allowedRequest.rerequestAllowed, "deferred refund should open manual gate");
+        assertFalse(allowedRequest.automaticDisputeRerequestUsed, "deferred refund should not consume automatic slot");
+        assertEq(
+            allowedRequest.requestTimestamp, request.requestTimestamp, "deferred refund should not advance timestamp"
+        );
+        assertEq(
+            optimisticOracle.deferredPayouts(usdc, address(reporter)), REWARD, "refund should be deferred to reporter"
+        );
+    }
+
     function test_priceDisputedUsesCurrentAutomationSettingAfterDisabledFirstDispute() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
@@ -677,6 +732,31 @@ contract OOReporterTest {
         assertEq(
             afterP4.requestTimestamp, request.requestTimestamp, "disabled P4 automation should not advance timestamp"
         );
+        assertEq(
+            afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available"
+        );
+    }
+
+    function test_priceSettledP4OpensManualGateWhenAutomaticRerequestTimestampNotAdvanced() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRerequestAllowed(REQUEST_ID, request.requestTimestamp, RerequestTrigger.InvalidSettlement);
+
+        optimisticOracle.settle(
+            address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, reporter.P4_PRICE()
+        );
+
+        RequestData memory afterP4 = reporter.getRequest(REQUEST_ID);
+        assertTrue(afterP4.rerequestAllowed, "same-block P4 should open manual gate");
+        assertFalse(afterP4.resolved, "P4 should not resolve request");
+        assertEq(afterP4.requestTimestamp, request.requestTimestamp, "same-block P4 should not advance timestamp");
         assertEq(
             afterP4.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "P4 should leave default budget available"
         );


### PR DESCRIPTION
Audit identified following issue:

> # Automatic re-requests inside OptimisticOracleV2 callbacks can revert and block disputes/settlements
>
> - Tag: H-01
> - Severity: High
> - Status: Open
>
> Root Cause: `OOReporter` calls `_requestPrice()` from `priceDisputed`/`priceSettled`; `OptimisticOracleV2` executes callbacks without `try/catch`, so any revert aborts `disputePriceFor()`/`_settle()`.
>
> Toy example:
>
> - A request is initialized with `automaticRerequestsEnabled = true`.
> - A user disputes a proposal.
> - `OptimisticOracleV2.disputePriceFor()` calls `OOReporter.priceDisputed()`.
> - `OOReporter` attempts an automatic re-request and reverts (e.g., `RequestRerequestTimestampNotAdvanced` or `InsufficientRewardBalance`).
> - The dispute transaction reverts and the request stays undisputed.
>
> Location: [`OOReporter.sol#L332-L375`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L332-L375)
>
> `OOReporter` enables `callbackOnPriceDisputed` and `callbackOnPriceSettled` for every oracle request it creates by calling [`setCallbacks(..., false, true, true)`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L550-L553) inside [`_requestPrice`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L531-L559) (used by [`initializeRequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L260-L293) and [`_executeRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L476-L498)). On disputes and settlement, the oracle invokes [`priceDisputed`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L332-L349) / [`priceSettled`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L351-L383), which may trigger an automatic re-request via [`_executeAutomaticRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L501-L507).
>
> The automatic re-request path can revert in reachable states. For example, [`_executeRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L476-L498) requires `block.timestamp` to strictly increase (so initializing and disputing within the same timestamp reverts), and [`_requestPrice`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L531-L559) can revert on `InsufficientRewardBalance` or on oracle-side checks (e.g., [`ManagedOptimisticOracleV2.requestPrice`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L260-L269) requires the requester to be whitelisted). `OptimisticOracleV2` performs `priceDisputed`/`priceSettled` as direct external calls (no `try/catch`) in [`disputePriceFor`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol#L451-L509) and [`_settle`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol#L670-L728), so a single callback revert cancels the dispute/settlement and can leave a request effectively undisputable/unsettleable.
>
> Consider making callback execution non-blocking by ensuring [`priceDisputed`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L332-L349) / [`priceSettled`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L351-L383) never revert (e.g., avoid calling [`_executeAutomaticRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L501-L507) from within the callback, or wrap it behind an external self-call with `try/catch`). Consider falling back to opening the manual re-request gate via [`_allowRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L599-L609) and emitting a failure event when automation fails, instead of reverting the oracle action.

This keeps automatic re-requests inside the callback path, but prechecks expected local blockers before attempting the replacement Managed OO request. If automation is disabled, the request timestamp has not advanced, or the reporter does not currently hold enough reward currency for the replacement request, the callback opens the oracle-initializer manual re-request gate instead of reverting the oracle dispute or P4 settlement.

The change intentionally does not introduce callback `try/catch`: unexpected oracle, token, or Managed OO config failures inside `_requestPrice` still surface as reverts rather than being hidden behind a broad manual fallback. The PM-facing `IOOReporter` surface remains unchanged, preserving the locked `OOReporterModule` integration.

Validation:

- `forge test --match-path test/OOReporter.t.sol` from `pm-v2-oo-reporter`
- `forge fmt --check` from `pm-v2-oo-reporter`
- `git diff --check -- pm-v2-oo-reporter/src/OOReporter.sol pm-v2-oo-reporter/test/OOReporter.t.sol`

Fixes: https://linear.app/uma/issue/FRO-73/h-01-automatic-re-requests-inside-optimisticoraclev2-callbacks-can