### PR TITLE
docs[ai-scan-l-03]: clarify P4 rerequest budget refresh

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -57,15 +57,16 @@ not when the request was initialized or last re-requested. When enabled, the fir
 automatically creates one replacement request without consuming manual re-request budget. Later dispute callbacks open
 the manual re-request gate and emit `RequestRerequestAllowed`.
 
-P4 settlements reset the active request's manual budget to the current default. When automatic re-requests are enabled,
-P4 settlements also create a replacement request without consuming manual budget. When automatic re-requests are
-disabled, P4 settlements open the manual re-request gate instead.
+P4 settlements intentionally reset the active request's manual budget to the current default. When automatic re-requests
+are enabled, P4 settlements also create a replacement request without consuming manual budget. When automatic
+re-requests are disabled, P4 settlements open the manual re-request gate instead so UMA-controlled oracle initializers can
+continue recovery.
 
 An enabled oracle initializer can call `rerequest(requestId, reward, proposalBond, liveness)` while the manual gate is
 open and manual budget remains. Manual re-requests can update the active reward, proposal bond, and liveness for the
 replacement request. Automatic re-requests reuse the active reward, proposal bond, and liveness. The owner can update
-the default budget for future initializations with `setDefaultRerequestBudget(...)`, and can top up or reduce an active
-unresolved request with `setRequestRerequestBudget(...)`.
+the default budget for future initializations and P4 refreshes with `setDefaultRerequestBudget(...)`, and can adjust an
+active unresolved request's current manual budget with `setRequestRerequestBudget(...)`.
 
 Lifecycle events that refer to a specific Managed OO request consistently lead with the external `requestId` and then
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -348,7 +348,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         }
     }
 
-    /// @notice Managed OO settlement callback. Stores final prices; resets the budget and re-requests on P4.
+    /// @notice Managed OO settlement callback. Stores final prices; refreshes recovery budget and re-requests on P4.
     /// @inheritdoc IOptimisticRequester
     function priceSettled(bytes32 identifier, uint256 timestamp, bytes memory requestRules, int256 price)
         external
@@ -361,8 +361,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         if (price == P4_PRICE) {
             // Reporter requests are event-based, so Managed OO rejects proposed P4; P4 here is DVM-resolved.
-            // Refill the manual budget so an enabled oracle initializer can continue without owner intervention if
-            // automation is disabled.
+            // Refill the manual budget so an enabled UMA-controlled oracle initializer can continue recovery without
+            // owner intervention if automation is disabled.
             uint256 budget = defaultRerequestBudget();
             if (request.manualRerequestsRemaining != budget) {
                 request.manualRerequestsRemaining = budget;

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -30,7 +30,9 @@ struct RequestData {
     bytes requestRules;
     /// @notice Final raw UMA outcome after settlement.
     int256 outcome;
-    /// @notice Remaining manual re-request budget. Seeded from the default at initialization and topped up by the owner.
+    /// @notice Remaining manual re-request budget.
+    /// @dev Seeded from the default at initialization, owner-adjustable, and intentionally refreshed to the default after
+    /// DVM-resolved P4 settlements so UMA-controlled oracle initializers can keep recovery moving.
     uint256 manualRerequestsRemaining;
     /// @notice Minimum liveness UMA is allowed to use for this request.
     uint64 minimumLiveness;
@@ -226,7 +228,7 @@ interface IOOReporter {
     /// @param enabled Whether oracleInitializer should be enabled.
     function setOracleInitializerEnabled(address oracleInitializer, bool enabled) external;
 
-    /// @notice Updates the default replacement-request budget for future initialized requests.
+    /// @notice Updates the default replacement-request budget for future initialized requests and P4 refreshes.
     /// @param newDefaultRerequestBudget New default re-request budget.
     function setDefaultRerequestBudget(uint256 newDefaultRerequestBudget) external;
 
@@ -288,7 +290,9 @@ interface IOOReporter {
     /// @param liveness Custom OO liveness period within the registered bounds.
     function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
-    /// @notice Updates the remaining re-request budget for an initialized unresolved request.
+    /// @notice Updates the remaining manual re-request budget for an initialized unresolved request.
+    /// @dev This operational top-up/adjustment knob does not permanently cap P4 recovery. A DVM-resolved P4 settlement
+    /// refreshes the request's manual budget to the current default before automatic or manual recovery continues.
     /// @param requestId Registered request ID.
     /// @param newManualRerequestsRemaining New remaining manual re-request budget, capped by the current default.
     function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external;


### PR DESCRIPTION
Audit identified following issue:

> # P4 settlement refills per-request re-request budget, bypassing owner-set limits
>
> - Tag: L-03
> - Severity: Low
> - Status: Open
>
> Root Cause: `priceSettled()` overwrites `manualRerequestsRemaining` with `defaultRerequestBudget()` on P4, even if the owner previously reduced the per-request budget.
>
> Toy example:
>
> - A request is initialized; the owner sets its manual budget to 0 via `setRequestRerequestBudget()`.
> - The associated Optimistic Oracle request is disputed and ultimately settles to `P4_PRICE`.
> - `priceSettled()` restores `manualRerequestsRemaining` back to `defaultRerequestBudget()`.
> - If `rerequestAllowed` is opened, an enabled `onlyOracleInitializer` can call `rerequest()` despite the owner-imposed cap.
>
> Location: [`OOReporter.priceSettled()`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L351-L383)
>
> `OOReporter` tracks per-request manual re-requests through `manualRerequestsRemaining`, which is decremented by [`rerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L296-L312) and can be lowered by the owner with [`setRequestRerequestBudget`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L315-L330). This mechanism is intended to cap how many manual re-requests an enabled oracle initializer can perform for a given `requestId`.
>
> In the Optimistic Oracle callback [`priceSettled`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L353-L383), the `price == P4_PRICE` branch refills `manualRerequestsRemaining` back to the contract-level [`defaultRerequestBudget()`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L166-L169) whenever the current value differs. This can unexpectedly override an owner's attempt to reduce a specific request's remaining manual re-requests (including setting it to 0 during an incident), enabling additional [`rerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L296-L312) calls and associated reward spending after an externally driven P4 settlement. This is most relevant when automation is disabled, since the P4 branch calls [`_allowRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L598-L609) to open `rerequestAllowed`.
>
> Consider avoiding any increase of `manualRerequestsRemaining` during the P4 callback, or gating the refill behind an explicit owner-controlled per-request flag (for example, only refilling when the owner has not overridden the budget for that request).

This keeps the current P4 behavior and clarifies it as intentional product behavior. `setRequestRerequestBudget` is an operational current-budget adjustment for UMA-controlled oracle initializers, not a permanent per-request stop condition for DVM-resolved P4 recovery. If UMA needs re-requests to stop, the offchain oracle-initializer path can stop submitting them.

The documentation now states that DVM-resolved P4 settlements intentionally refresh the active request's manual budget to the current default so recovery can continue, especially when automation is disabled and the manual gate is opened. It also updates the default-budget and request-budget NatSpec so future readers do not interpret the setter as a durable cap that P4 must preserve.

Validation:

- `forge fmt --check` from `pm-v2-oo-reporter`
- `git diff --cached --check -- pm-v2-oo-reporter/src/interfaces/IOOReporter.sol pm-v2-oo-reporter/src/OOReporter.sol pm-v2-oo-reporter/README.md`

Fixes: https://linear.app/uma/issue/FRO-76/l-03-p4-settlement-refills-per-request-re-request-budget-bypassing