### PR TITLE
docs[ai-scan-m-01]: clarify requester namespace model

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -34,8 +34,8 @@ per requester.
 
 The reporter reserves each `(priceIdentifier, requestRules)` tuple globally across enabled requesters in the
 deployment. This prevents two request IDs from pointing at the same UMA request identity. Independent integrations that
-need overlapping UMA request identities should use separate reporter deployments or explicitly domain-separate request
-rules.
+need the exact same UMA request identity should use separate reporter deployments; integrations with similar rules can
+domain-separate request rules so their UMA request identities differ.
 
 ## Responsibilities
 

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -26,6 +26,17 @@ function getRequestResolution(bytes32 requestId) external view returns (int256);
 
 `OOReporter` uses `requestId` as the external key. It does not compute, return, expose, or require market-specific question IDs, and it does not accept or store a market initializer.
 
+## Deployment Model
+
+Each `OOReporter` deployment exposes one owner-managed request namespace. Enabled requester addresses are expected to
+coordinate on request identity within that namespace; the contract does not isolate identical UMA request identities
+per requester.
+
+The reporter reserves each `(priceIdentifier, requestRules)` tuple globally across enabled requesters in the
+deployment. This prevents two request IDs from pointing at the same UMA request identity. Independent integrations that
+need overlapping UMA request identities should use separate reporter deployments or explicitly domain-separate request
+rules.
+
 ## Responsibilities
 
 `OOReporter` owns:
@@ -45,7 +56,9 @@ The prediction market integration owns:
 
 ## Request Lifecycle
 
-An enabled requester first calls `registerRequest(...)` with its external `requestId`, UMA price identifier, raw request rules, and allowed liveness range. The reporter reserves the `(priceIdentifier, requestRules)` tuple globally so two request IDs cannot point at the same UMA request identity.
+An enabled requester first calls `registerRequest(...)` with its external `requestId`, UMA price identifier, raw request
+rules, and allowed liveness range. The reporter reserves the `(priceIdentifier, requestRules)` tuple globally within
+the deployment so two request IDs cannot point at the same UMA request identity.
 
 An enabled UMA oracle initializer later calls `initializeRequest(requestId, reward, proposalBond, liveness)`. The selected
 liveness must be non-zero and inside the registered range. Each initialized request receives the current

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -21,7 +21,8 @@ import {IOptimisticRequester} from "./interfaces/IOptimisticRequester.sol";
 /// @title OOReporter
 /// @notice UMA-owned Managed OO requester and raw outcome source for prediction market request IDs.
 /// @dev Approved requesters register request IDs here. UMA initializes and manages the OO lifecycle,
-///      then this reporter stores the final raw UMA price for market-side translation.
+///      then this reporter stores the final raw UMA price for market-side translation. Enabled requesters
+///      share one owner-managed request namespace and are expected to coordinate on request identity.
 /// @custom:security-contact bugs@umaproject.org
 contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable, IOOReporter, IOptimisticRequester {
     using SafeERC20 for IERC20;

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -255,9 +255,10 @@ interface IOOReporter {
     /// @notice Registers a requester-defined request ID and its UMA request identity before OO initialization.
     /// @dev The reporter reserves each price identifier and request rules pair globally across approved requesters.
     /// Enabled requesters share one owner-managed request namespace; the contract does not isolate identical UMA
-    /// request identities per requester. Independent integrations that need overlapping UMA request identities should
-    /// use separate reporter deployments or explicitly domain-separate request rules. Requesters should preserve an
-    /// admin recovery path for rules or liveness ranges that become unusable before initialization.
+    /// request identities per requester. Independent integrations that need the exact same UMA request identity should
+    /// use separate reporter deployments; integrations with similar rules can domain-separate request rules so their
+    /// UMA request identities differ. Requesters should preserve an admin recovery path for rules or liveness ranges
+    /// that become unusable before initialization.
     /// @param requestId Requester-defined request ID to bind to the UMA request identity.
     /// @param priceIdentifier UMA price identifier to request.
     /// @param requestRules Raw UMA request rules supplied by the requester.

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -254,8 +254,10 @@ interface IOOReporter {
 
     /// @notice Registers a requester-defined request ID and its UMA request identity before OO initialization.
     /// @dev The reporter reserves each price identifier and request rules pair globally across approved requesters.
-    /// Requesters should preserve an admin recovery path for rules or liveness ranges that become unusable before
-    /// initialization.
+    /// Enabled requesters share one owner-managed request namespace; the contract does not isolate identical UMA
+    /// request identities per requester. Independent integrations that need overlapping UMA request identities should
+    /// use separate reporter deployments or explicitly domain-separate request rules. Requesters should preserve an
+    /// admin recovery path for rules or liveness ranges that become unusable before initialization.
     /// @param requestId Requester-defined request ID to bind to the UMA request identity.
     /// @param priceIdentifier UMA price identifier to request.
     /// @param requestRules Raw UMA request rules supplied by the requester.


### PR DESCRIPTION
Audit identified following issue:

> # Irreversible request registration enables permanent request key squatting
>
> - Tag: M-01
> - Severity: Medium
> - Status: Open
>
> Root Cause: `registerRequest()` permanently reserves both `requestId` and `keccak256(abi.encode(identifier, requestRules))` without an unregistration path; disabling a requester does not clear reservations.
>
> Toy example:
>
> - Requester A (enabled) calls `registerRequest(idA, identX, rulesY, ...)`.
> - The call permanently stores `requestIdsByReporterKey[keccak256(abi.encode(identX, rulesY))] = idA`.
> - Requester B later calls `registerRequest(idB, identX, rulesY, ...)`.
> - The call reverts with `ReporterRequestKeyAlreadyRegistered` and the `(identX, rulesY)` identity is permanently blocked.
>
> Location: [`OOReporter.registerRequest()`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L203-L244)
>
> `OOReporter` allows enabled requesters to reserve a requester-defined `requestId` and a global `(identifier, requestRules)` identity in `registerRequest` by setting `request.registered = true` and writing `requestIdsByReporterKey[reporterRequestKey] = requestId`. The key is computed in `_reporterRequestKey` as `keccak256(abi.encode(identifier, requestRules))` and omits the requester address.
>
> Registration is irreversible: later calls to `registerRequest` revert if either `request.registered` is already set or the derived `reporterRequestKey` is already mapped. Because the key is global across all enabled requesters, any enabled requester can permanently reserve an `(identifier, requestRules)` pair and block other requesters from registering another `requestId` for that identity. Disabling a requester only updates an allowlist bit and does not clear existing reservations.
>
> Consider adding an explicit unregistration/reassignment mechanism for `requestId` and `requestIdsByReporterKey` entries, or scoping `reporterRequestKey` to the registrar if global uniqueness across requesters is not required.

This keeps the current request-key behavior and clarifies it as part of the reporter's owner-managed namespace model. `OOReporter` reserves `(priceIdentifier, requestRules)` globally within a deployment so two request IDs cannot point at the same UMA request identity. Enabled requesters are therefore expected to coordinate on request identity within that namespace rather than being isolated per requester.

The documentation now states that independent integrations needing the exact same UMA request identity should use separate reporter deployments, while integrations with similar rules can domain-separate request rules so their UMA request identities differ. It also updates the contract and interface NatSpec so future readers do not interpret requester allowlisting as a multi-tenant isolation boundary.

Validation:

- `forge fmt --check src/OOReporter.sol src/interfaces/IOOReporter.sol` from `pm-v2-oo-reporter`
- `git diff --cached --check -- pm-v2-oo-reporter/src/interfaces/IOOReporter.sol pm-v2-oo-reporter/src/OOReporter.sol pm-v2-oo-reporter/README.md`

Fixes: https://linear.app/uma/issue/FRO-77/m-01-irreversible-request-registration-enables-permanent-request-key