### PR TITLE
docs[ai-scan-m-02]: document trusted resolver finality

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -71,6 +71,17 @@ Lifecycle events that refer to a specific Managed OO request consistently lead w
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,
 re-request-gate, rules-update, and resolution logs easy to correlate after a request has been replaced.
 
+## Trusted Resolver Dependency
+
+`OOReporter` stores final outcomes only after Managed OO settles the active request and calls `priceSettled(...)`.
+Managed OO settlement is intentionally performed by trusted UMA resolver bots rather than permissionless callers. This
+lets UMA use short liveness for routine proposals while resolver infrastructure can escalate uncertain requests to
+human review before settlement.
+
+If no trusted resolver settles the active request, `isRequestResolved(requestId)` remains false and
+`getRequestResolution(requestId)` reverts. Downstream integrations should monitor this resolver dependency and keep any
+timeout or administrative recovery path in the market-side module that translates raw UMA outcomes and finalizes markets.
+
 ## Rules Updates
 
 Only the requester that registered a `requestId` can update rules for that request. Rules updates are stored as:

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -73,7 +73,8 @@ re-request-gate, rules-update, and resolution logs easy to correlate after a req
 
 ## Trusted Resolver Dependency
 
-`OOReporter` stores final outcomes only after Managed OO settles the active request and calls `priceSettled(...)`.
+`OOReporter` stores final outcomes only after Managed OO settles the active request and calls `priceSettled(...)` with a
+non-P4 price. A P4 settlement re-requests instead of finalizing.
 Managed OO settlement is intentionally performed by trusted UMA resolver bots rather than permissionless callers. This
 lets UMA use short liveness for routine proposals while resolver infrastructure can escalate uncertain requests to
 human review before settlement.

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -293,12 +293,12 @@ interface IOOReporter {
     /// @param newManualRerequestsRemaining New remaining manual re-request budget, capped by the current default.
     function setRequestRerequestBudget(bytes32 requestId, uint256 newManualRerequestsRemaining) external;
 
-    /// @notice Returns whether a final reporter outcome is available for requestId.
+    /// @notice Returns whether Managed OO settlement has produced a final reporter outcome for requestId.
     /// @param requestId Registered request ID.
     /// @return True if the reporter has stored a final outcome.
     function isRequestResolved(bytes32 requestId) external view returns (bool);
 
-    /// @notice Returns the final raw UMA outcome for requestId.
+    /// @notice Returns the final raw UMA outcome for requestId after trusted resolver settlement.
     /// @param requestId Registered request ID.
     /// @return Final raw UMA outcome.
     function getRequestResolution(bytes32 requestId) external view returns (int256);

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -298,7 +298,7 @@ interface IOOReporter {
     /// @return True if the reporter has stored a final outcome.
     function isRequestResolved(bytes32 requestId) external view returns (bool);
 
-    /// @notice Returns the final raw UMA outcome for requestId after trusted resolver settlement.
+    /// @notice Returns the final raw UMA outcome for requestId after non-P4 trusted resolver settlement.
     /// @param requestId Registered request ID.
     /// @return Final raw UMA outcome.
     function getRequestResolution(bytes32 requestId) external view returns (int256);


### PR DESCRIPTION
Audit identified following issue:

> # Permissioned settlement makes OOReporter finality dependent on resolver liveness
>
> - Tag: M-02
> - Severity: Medium
> - Status: Open
>
> Root Cause: `OOReporter` persists outcomes only in `priceSettled()`, but `ManagedOptimisticOracleV2.settle()` is `onlyResolver` and `settleAndGetPrice()` does not settle.
>
> Toy example:
>
> - A request is proposed and liveness elapses.
> - No resolver calls `ManagedOptimisticOracleV2.settle()`.
> - The `priceSettled()` callback never executes.
> - `OOReporter.getRequestResolution()` keeps reverting and the market cannot finalize.
>
> Location: [`OOReporter.sol#L351-L395`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L351-L395)
>
> `OOReporter` finalizes a request by setting `request.resolved` and `request.outcome` only in the [`priceSettled`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L351-L383) callback. Until this callback runs, [`getRequestResolution`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L390-L395) reverts, and there is no alternate method in `OOReporter` to pull settlement state from the oracle and persist it.
>
> In `ManagedOptimisticOracleV2`, settlement is permissioned: [`settle`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L412-L420) is gated by [`onlyResolver`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L158-L161) (i.e., `RESOLVER_ROLE`), and [`settleAndGetPrice`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L390-L399) is a read-only compatibility override that requires the request to already be settled. Requests can reach `State.Expired` after liveness elapses even when not settled ([`_getState`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol#L767-L787)), and `ManagedOptimisticOracleV2` explicitly treats settlement as permissioned in its dispute-state logic ([`_getStateForDispute`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L592-L604)). If resolvers are offline, censored, or misconfigured, requests can remain unsettled indefinitely and `OOReporter` consumers can become permanently unfinalizable.
>
> Consider providing an onchain escape hatch that reduces reliance on permissioned settlement for `OOReporter` consumers (e.g., permissionless settlement for reporter-created requests, redundant resolver sets with monitored failover, or a governed emergency resolution path). Consider adding explicit integration guidance that `OOReporter` finality is conditional on resolver liveness, and require downstream markets to include a timeout-based administrative recovery path.

This keeps the trusted resolver settlement model and documents it as an explicit finality dependency rather than adding a permissionless settlement escape hatch. Managed OO settlement is intentionally performed by trusted UMA resolver bots so short-liveness requests can be settled quickly unless OTB escalates them to human review first.

The documentation now states that `OOReporter` stores final outcomes only after Managed OO calls `priceSettled(...)` with a non-P4 price, that P4 settlement re-requests instead of finalizing, that unresolved requests remain unavailable until a trusted resolver settles the active request, and that monitoring plus timeout or administrative recovery should stay in the market-side module that translates raw UMA outcomes and finalizes markets. The interface NatSpec also clarifies that `getRequestResolution` is downstream of non-P4 Managed OO trusted resolver settlement.

Validation:

- `forge fmt --check src/interfaces/IOOReporter.sol` from `pm-v2-oo-reporter`
- `git diff --check -- pm-v2-oo-reporter/README.md pm-v2-oo-reporter/src/interfaces/IOOReporter.sol`

Fixes: https://linear.app/uma/issue/FRO-78/m-02-permissioned-settlement-makes-ooreporter-finality-dependent-on