### PR TITLE
docs[ai-scan-m-03]: clarify reporter-requested OO parameters

### DIFF
--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -6,9 +6,11 @@ struct RequestData {
     uint256 requestTimestamp;
     /// @notice Reward amount used for the active Managed OO request.
     uint256 reward;
-    /// @notice Proposal bond used for the active Managed OO request.
+    /// @notice Proposal bond requested by the reporter for the active Managed OO request.
+    /// @dev The effective proposal bond can differ if Managed OO request-manager preconfigs apply at proposal time.
     uint256 proposalBond;
-    /// @notice Custom liveness used for the active Managed OO request.
+    /// @notice Custom liveness requested by the reporter for the active Managed OO request.
+    /// @dev The effective proposal liveness can differ if Managed OO request-manager preconfigs apply at proposal time.
     uint64 liveness;
     /// @notice Whether an approved requester has registered this request.
     bool registered;
@@ -154,6 +156,8 @@ interface IOOReporter {
         uint64 maximumLiveness
     );
     /// @notice Emitted when an approved oracle initializer creates the first Managed OO request.
+    /// @dev proposalBond and liveness are reporter-requested parameters. Effective proposal-time values can differ
+    /// if Managed OO request-manager preconfigs apply.
     event RequestInitialized(
         bytes32 indexed requestId,
         uint256 indexed requestTimestamp,
@@ -177,6 +181,8 @@ interface IOOReporter {
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
     );
     /// @notice Emitted when the reporter creates a replacement Managed OO request.
+    /// @dev proposalBond and liveness are reporter-requested parameters. Effective proposal-time values can differ
+    /// if Managed OO request-manager preconfigs apply.
     event RequestRerequested(
         bytes32 indexed requestId,
         uint256 indexed requestTimestamp,
@@ -277,15 +283,19 @@ interface IOOReporter {
     /// @notice Creates the Managed OO request for a registered request.
     /// @param requestId Registered request ID.
     /// @param reward Reward offered to a successful OO proposer.
-    /// @param proposalBond Bond required from OO proposers/disputers, or zero to use the OO default.
-    /// @param liveness Custom OO liveness period within the registered bounds.
+    /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective
+    /// proposal bond can differ if Managed OO request-manager preconfigs apply at proposal time.
+    /// @param liveness Custom OO liveness period within the registered bounds. The effective proposal liveness can
+    /// differ if Managed OO request-manager preconfigs apply at proposal time.
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Allows an enabled oracle initializer to create a replacement Managed OO request after a callback opens the gate.
     /// @param requestId Registered request ID.
     /// @param reward Reward amount for the replacement request.
-    /// @param proposalBond Bond required from OO proposers/disputers, or zero to use the OO default.
-    /// @param liveness Custom OO liveness period within the registered bounds.
+    /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective
+    /// proposal bond can differ if Managed OO request-manager preconfigs apply at proposal time.
+    /// @param liveness Custom OO liveness period within the registered bounds. The effective proposal liveness can
+    /// differ if Managed OO request-manager preconfigs apply at proposal time.
     function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Updates the remaining re-request budget for an initialized unresolved request.


### PR DESCRIPTION
Audit identified following issue:

> # Request-manager overrides can desync OOReporter parameters and brick proposals
>
> - Tag: M-03
> - Severity: Medium
> - Status: Open
>
> Root Cause: `ManagedOptimisticOracleV2` mutates bond/liveness and enforces proposer whitelists at proposal time using a timestamp-less key; `OOReporter` validates/emits parameters at request time only.
>
> Toy example:
>
> - A request is registered with liveness bounds `[1 day, 2 days]`.
> - An oracle initializer calls `initializeRequest(..., liveness = 1 day, proposalBond = 100)`.
> - A request manager configures a custom proposer whitelist that contains no addresses for the managed-request key.
> - All proposals revert, so no disputes/settlements occur and `OOReporter` never emits `RequestRerequestAllowed` (set in [`_allowRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L599-L609)).
>
> Location: [`ManagedOptimisticOracleV2.sol#L354-L379`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L354-L379)
>
> `OOReporter` registers per-request liveness bounds in [`registerRequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L203-L244) and enforces them at initialization and manual re-request time via [`_requireValidRequestLiveness`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L561-L567). It also stores and emits `proposalBond` and `liveness` during [`initializeRequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L260-L293) and re-requests (via [`_executeRerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L476-L498)). Consumers may therefore treat these stored/emitted values as authoritative for the active oracle request.
>
> However, `ManagedOptimisticOracleV2` applies request-manager “preconfigs” during proposal: [`proposePriceFor`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L354-L379) overwrites `request.requestSettings.bond` and `request.requestSettings.customLiveness` and enforces an effective proposer whitelist for both `proposer` and `msg.sender`. These settings are controlled by accounts with `REQUEST_MANAGER_ROLE` (gated by [`onlyRequestManager`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L150-L153)). The overrides are keyed by [`getManagedRequestId(requester, identifier, ancillaryData)`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol#L470-L476), which omits the timestamp, so the same overrides apply across `OOReporter` re-requests that only change `requestTimestamp`. This can (a) make the oracle’s effective liveness/bond diverge from `OOReporter`’s stored values (including outside the registered bounds), misleading onchain/offchain consumers, and (b) permanently brick a request by configuring a proposer whitelist that excludes all callers. In the “no proposal possible” case, the request remains in `State.Requested` ([`_getState`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol#L767-L787)), no callbacks execute, and `OOReporter`’s manual re-request entrypoint stays blocked by [`RequestRerequestNotAllowed`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L295-L312).
>
> Consider hardening integration boundaries by either (a) prohibiting request-manager overrides for `OOReporter` requests (role separation / dedicated oracle instance), or (b) making `OOReporter` treat oracle-side settings as the source of truth (e.g., emit/serve “effective” parameters by reading `oracle.getRequest(...)` at consumption time). Consider adding a recovery path for requests stuck in `State.Requested` (e.g., an owner/initializer override to bypass the `request.rerequestAllowed` gate checked in [`rerequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L295-L312) after a timeout), and require proposer whitelists to be either disabled or non-empty.

This keeps the existing Managed OO trust boundary and documents the parameter semantics at the `OOReporter` interface instead of changing reporter behavior. Managed OO request-manager preconfigs are privileged oracle-level configuration and can still affect the effective proposal-time bond, liveness, or proposer whitelist for a request.

The documentation now states that `proposalBond` and `liveness` are reporter-requested parameters for the active Managed OO request, not final attestations of the effective proposal-time settings. The interface NatSpec also clarifies this on the stored request state, `RequestInitialized` / `RequestRerequested` events, and `initializeRequest` / `rerequest` parameters.

This mirrors the existing production `UmaCtfAdapter` trust boundary while making the split `OOReporter` interface less ambiguous for downstream consumers. PM-side market recovery remains in the v2 adapter/aggregator layer, where `OracleAggregator.resolveResult(...)` can finalize by arbitrator or admin override without requiring `OOReporterModule.report(...)` to succeed.

Validation:

- `forge fmt --check src/interfaces/IOOReporter.sol` from `pm-v2-oo-reporter`
- `git diff --check -- pm-v2-oo-reporter/src/interfaces/IOOReporter.sol`

Fixes: https://linear.app/uma/issue/FRO-79/m-03-request-manager-overrides-can-desync-ooreporter-parameters-and