### PR TITLE
docs[ai-scan-n-01]: clarify rules update identity

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -24,7 +24,7 @@ function isRequestResolved(bytes32 requestId) external view returns (bool);
 function getRequestResolution(bytes32 requestId) external view returns (int256);
 ```
 
-`OOReporter` uses `requestId` as the external key. It does not compute, return, expose, or require market-specific question IDs, and it does not accept or store a market initializer.
+`OOReporter` uses `requestId` as the external key. It does not compute, return, expose, or require market-specific question IDs, and it does not accept or store a market initializer. Tuple-based lookups use the original `(priceIdentifier, requestRules)` supplied during registration.
 
 ## Responsibilities
 
@@ -73,7 +73,9 @@ re-request-gate, rules-update, and resolution logs easy to correlate after a req
 
 ## Rules Updates
 
-Only the requester that registered a `requestId` can update rules for that request. Rules updates are stored as:
+Only the requester that registered a `requestId` can update rules for that request. Rules updates are append-only history keyed by `requestId`; they do not replace the original registered rules or create a new `(priceIdentifier, updatedRules)` lookup alias. Consumers should use `requestId` as the stable identity when reading update history.
+
+Rules updates are stored as:
 
 ```solidity
 struct RequestRulesUpdate {

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -270,6 +270,9 @@ interface IOOReporter {
     ) external;
 
     /// @notice Posts updated request rules for offchain consumers without changing the active OO tuple.
+    /// @dev Updates are append-only history keyed by requestId. They do not replace the original request rules
+    /// registered for the request, and they do not create or reserve a `(priceIdentifier, updatedRules)` lookup alias.
+    /// Consumers should treat requestId as the stable identity for reading update history.
     /// @param requestId Registered request ID.
     /// @param updatedRules Updated prediction market request rules.
     function updateRequestRules(bytes32 requestId, bytes calldata updatedRules) external;
@@ -309,8 +312,10 @@ interface IOOReporter {
     function getRequest(bytes32 requestId) external view returns (RequestData memory);
 
     /// @notice Returns the request ID registered for a UMA request identity.
+    /// @dev `requestRules` must be the original rules supplied to registerRequest. Rules posted through
+    /// updateRequestRules are informational history and are not valid replacement lookup keys.
     /// @param priceIdentifier UMA price identifier.
-    /// @param requestRules Raw UMA request rules.
+    /// @param requestRules Original raw UMA request rules registered for the request.
     /// @return requestId Registered request ID.
     function getRequestId(bytes32 priceIdentifier, bytes calldata requestRules) external view returns (bytes32);
 
@@ -325,8 +330,10 @@ interface IOOReporter {
     function getLatestRequestRulesUpdate(bytes32 requestId) external view returns (RequestRulesUpdate memory);
 
     /// @notice Returns all request-rules updates posted for a UMA request identity.
+    /// @dev `requestRules` must be the original rules supplied to registerRequest, not a value previously posted
+    /// through updateRequestRules. Prefer the requestId overload when the stable external request ID is already known.
     /// @param priceIdentifier UMA price identifier.
-    /// @param requestRules Raw UMA request rules.
+    /// @param requestRules Original raw UMA request rules registered for the request.
     /// @return Request-rules update history.
     function getRequestRulesUpdates(bytes32 priceIdentifier, bytes calldata requestRules)
         external
@@ -334,8 +341,10 @@ interface IOOReporter {
         returns (RequestRulesUpdate[] memory);
 
     /// @notice Returns the latest request-rules update posted for a UMA request identity.
+    /// @dev `requestRules` must be the original rules supplied to registerRequest, not a value previously posted
+    /// through updateRequestRules. Prefer the requestId overload when the stable external request ID is already known.
     /// @param priceIdentifier UMA price identifier.
-    /// @param requestRules Raw UMA request rules.
+    /// @param requestRules Original raw UMA request rules registered for the request.
     /// @return Latest request-rules update.
     function getLatestRequestRulesUpdate(bytes32 priceIdentifier, bytes calldata requestRules)
         external


### PR DESCRIPTION
Audit identified following issue:

> # updateRequestRules() can cause off-chain requestId misbinding when using updatedRules as identity
>
> - Tag: N-01
> - Severity: Note
>
> Root Cause: `updateRequestRules()` records `updatedRules` as history only, so `(priceIdentifier, updatedRules)` remains a separate, registerable key that can map to a different `requestId`.
>
> Toy example:
>
> - Requester A calls `registerRequest()` with `(priceIdentifier = PID, requestRules = R0)` and chooses `requestId = X`.
> - Requester A calls `updateRequestRules(X, R1)`.
> - Requester B calls `registerRequest()` with `(priceIdentifier = PID, requestRules = R1)` and chooses `requestId = Y`.
> - A consumer calling `getRequestId(PID, R1)` resolves `Y` instead of `X`.
>
> Location: [`OOReporter.registerRequest()` / `OOReporter.updateRequestRules()`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L202-L257)
>
> `OOReporter` exposes [`registerRequest`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L202-L244) to create a `requestId` and bind it to the reporter lookup key `keccak256(abi.encode(priceIdentifier, requestRules))` via [`_reporterRequestKey`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L618-L620). Consumers can later resolve this mapping using [`getRequestId`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L403-L410).
>
> However, [`updateRequestRules`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L246-L257) only appends `updatedRules` to `requestRulesUpdates[requestId]` and emits `RequestRulesUpdated`; it does not update `request.requestRules` or [`requestIdsByReporterKey`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/OOReporter.sol#L231-L243). This means `(priceIdentifier, updatedRules)` is not reserved for the original `requestId`. A different enabled requester can register a new request under `(priceIdentifier, updatedRules)`, and any off-chain integration that (incorrectly) treats `updatedRules` as the canonical identity and calls `getRequestId(priceIdentifier, updatedRules)` can be redirected to the new request, or revert if no such request exists. The interface comment already states that rules updates are for off-chain consumers "without changing the active OO tuple". See [`IOOReporter.updateRequestRules`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol#L272-L275).
>
> Consider reducing consumer confusion by making the informational-only semantics explicit in the API and documentation. For example, rename `updateRequestRules()` to indicate history, and document that `requestId` is the stable external identifier (as described in [`pm-v2-oo-reporter/README.md`](https://github.com/UMAprotocol/managed-oracle/blob/2f4e84f873e21530ee7bf35c8b4052015fca420a/pm-v2-oo-reporter/README.md#L27-L28)). If supporting lookups by updated rules is desired, consider adding an explicit aliasing mechanism that maps specific `updatedRules` values to the original `requestId`.

This keeps the ABI locked for Polymarket-side audits and clarifies the informational-only semantics in NatSpec and package documentation instead of changing reporter behavior.

The documentation now states that `requestId` is the stable external identity for request-rules update history. Tuple-based lookups use the original `(priceIdentifier, requestRules)` supplied at registration; values later posted through `updateRequestRules(...)` do not replace the original rules and do not create `(priceIdentifier, updatedRules)` lookup aliases.

The interface NatSpec mirrors that behavior on `updateRequestRules`, `getRequestId`, and the tuple-based `getRequestRulesUpdates` / `getLatestRequestRulesUpdate` overloads so off-chain consumers do not treat updated rules as canonical identity.

Validation:

- `forge fmt --check src/interfaces/IOOReporter.sol` from `pm-v2-oo-reporter`
- `git diff --check -- pm-v2-oo-reporter/README.md pm-v2-oo-reporter/src/interfaces/IOOReporter.sol`
- `forge test --match-path test/OOReporter.t.sol` from `pm-v2-oo-reporter`

Fixes: https://linear.app/uma/issue/FRO-80/n-01-updaterequestrules-can-cause-off-chain-requestid-misbinding-when