### PR TITLE
pm-v2-oo-reporter: pass rules updates through to Managed OO

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,8 @@ ast = true
 build_info = true
 extra_output = ["storageLayout"]
 optimizer = true
+optimizer_runs = 25
+via_ir = true
 
 # Fork testing configuration
 [rpc_endpoints]

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -34,7 +34,7 @@ function getRequestResolution(bytes32 requestId) external view returns (int256);
 - UMA oracle initializer allowlisting;
 - Managed OO request creation;
 - reward, bond, request-specific liveness bounds, automatic re-request controls, and manual re-request budget controls;
-- request rules update history for active requests;
+- forwarding request rules updates to the Managed OO for active requests;
 - raw UMA settlement storage.
 
 The prediction market integration owns:
@@ -73,18 +73,9 @@ re-request-gate, rules-update, and resolution logs easy to correlate after a req
 
 ## Rules Updates
 
-Only the requester that registered a `requestId` can update rules for that request. Rules updates are stored as:
+Only the requester that registered a `requestId` can update rules for that request. The reporter does not store update history itself; it forwards the update to the Managed OO via `updateRequestRules(priceIdentifier, requestRules, updatedRules)`, which records the history (keyed by its managed request id) and emits its own `RequestRulesUpdated` event. The reporter additionally emits a `RequestRulesUpdated` event carrying the requester-facing `requestId` and updater address for self-contained logs.
 
-```solidity
-struct RequestRulesUpdate {
-    uint256 timestamp;
-    bytes updatedRules;
-}
-```
-
-The rules update event includes the updater address for self-contained logs. Stored attribution is derivable from `getRequest(requestId).requester`.
-
-Rules updates are rejected after the request has resolved.
+Updates can be forwarded both before and after the request is initialized. Rules updates are rejected after the request has resolved.
 
 ## Foundry Dependency Import
 

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -8,13 +8,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
-import {
-    IOOReporter,
-    RequestData,
-    RequestRulesUpdate,
-    RerequestTrigger,
-    RerequestType
-} from "./interfaces/IOOReporter.sol";
+import {IOOReporter, RequestData, RerequestTrigger, RerequestType} from "./interfaces/IOOReporter.sol";
 import {IOptimisticOracleV2} from "./interfaces/IOptimisticOracleV2.sol";
 import {IOptimisticRequester} from "./interfaces/IOptimisticRequester.sol";
 
@@ -55,8 +49,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         mapping(bytes32 requestId => RequestData request) requests;
         /// @notice Mapping of `(priceIdentifier, requestRules)` key to requester-defined request ID.
         mapping(bytes32 reporterRequestKey => bytes32 requestId) requestIdsByReporterKey;
-        /// @notice Mapping of requester-defined request ID to request rules update history.
-        mapping(bytes32 requestId => RequestRulesUpdate[] updates) requestRulesUpdates;
         /// @notice Default re-request budget seeded onto each request at initialization.
         uint256 defaultRerequestBudget;
         /// @notice Whether first-dispute and P4 automatic re-requests are enabled.
@@ -249,9 +241,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         if (request.resolved) revert RequestAlreadyResolved();
         if (msg.sender != request.requester) revert CallerNotRequestRegistrar();
 
-        RequestRulesUpdate memory requestRulesUpdate =
-            RequestRulesUpdate({timestamp: block.timestamp, updatedRules: updatedRules});
-        _getStorage().requestRulesUpdates[requestId].push(requestRulesUpdate);
+        optimisticOracle().updateRequestRules(request.priceIdentifier, request.requestRules, updatedRules);
 
         emit RequestRulesUpdated(requestId, block.timestamp, msg.sender, updatedRules);
     }
@@ -407,39 +397,6 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     {
         requestId = requestIdsByReporterKey(_reporterRequestKey(priceIdentifier, requestRules));
         if (requestId == bytes32(0)) revert RequestNotRegistered();
-    }
-
-    /// @inheritdoc IOOReporter
-    function getRequestRulesUpdates(bytes32 requestId) public view returns (RequestRulesUpdate[] memory) {
-        _requireRegistered(requestId);
-        return _getStorage().requestRulesUpdates[requestId];
-    }
-
-    /// @inheritdoc IOOReporter
-    function getLatestRequestRulesUpdate(bytes32 requestId) public view returns (RequestRulesUpdate memory) {
-        _requireRegistered(requestId);
-        RequestRulesUpdate[] storage updates = _getStorage().requestRulesUpdates[requestId];
-        uint256 updateCount = updates.length;
-        if (updateCount == 0) revert RequestRulesUpdateUnavailable();
-        return updates[updateCount - 1];
-    }
-
-    /// @inheritdoc IOOReporter
-    function getRequestRulesUpdates(bytes32 priceIdentifier, bytes calldata requestRules)
-        external
-        view
-        returns (RequestRulesUpdate[] memory)
-    {
-        return getRequestRulesUpdates(getRequestId(priceIdentifier, requestRules));
-    }
-
-    /// @inheritdoc IOOReporter
-    function getLatestRequestRulesUpdate(bytes32 priceIdentifier, bytes calldata requestRules)
-        external
-        view
-        returns (RequestRulesUpdate memory)
-    {
-        return getLatestRequestRulesUpdate(getRequestId(priceIdentifier, requestRules));
     }
 
     /// @inheritdoc IOOReporter

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -38,13 +38,6 @@ struct RequestData {
     uint64 maximumLiveness;
 }
 
-struct RequestRulesUpdate {
-    /// @notice Block timestamp when the rules update was posted.
-    uint256 timestamp;
-    /// @notice Updated prediction market request rules.
-    bytes updatedRules;
-}
-
 enum RerequestTrigger {
     /// @dev Managed OO dispute callback opened the re-request gate.
     Dispute,
@@ -125,8 +118,6 @@ interface IOOReporter {
     error RequestLivenessOutOfRange(uint64 liveness, uint64 minimumLiveness, uint64 maximumLiveness);
     /// @notice Thrown when a final reporter outcome is requested before one is available.
     error RequestResolutionUnavailable();
-    /// @notice Thrown when the latest rules update is requested before any update is posted.
-    error RequestRulesUpdateUnavailable();
     /// @notice Thrown when Managed OO has no deferred reward payout for the reporter.
     error DeferredPayoutUnavailable(address rewardCurrency);
     /// @notice Thrown when the reporter cannot fund a requested reward amount.
@@ -269,7 +260,8 @@ interface IOOReporter {
         uint64 maximumLiveness
     ) external;
 
-    /// @notice Posts updated request rules for offchain consumers without changing the active OO tuple.
+    /// @notice Forwards updated request rules to the Managed OO, which records them against the active OO request.
+    /// @dev Does not change the active OO request tuple; the Managed OO stores the update history and emits its own event.
     /// @param requestId Registered request ID.
     /// @param updatedRules Updated prediction market request rules.
     function updateRequestRules(bytes32 requestId, bytes calldata updatedRules) external;
@@ -313,34 +305,6 @@ interface IOOReporter {
     /// @param requestRules Raw UMA request rules.
     /// @return requestId Registered request ID.
     function getRequestId(bytes32 priceIdentifier, bytes calldata requestRules) external view returns (bytes32);
-
-    /// @notice Returns all request-rules updates posted for requestId.
-    /// @param requestId Registered request ID.
-    /// @return Request-rules update history.
-    function getRequestRulesUpdates(bytes32 requestId) external view returns (RequestRulesUpdate[] memory);
-
-    /// @notice Returns the latest request-rules update posted for requestId.
-    /// @param requestId Registered request ID.
-    /// @return Latest request-rules update.
-    function getLatestRequestRulesUpdate(bytes32 requestId) external view returns (RequestRulesUpdate memory);
-
-    /// @notice Returns all request-rules updates posted for a UMA request identity.
-    /// @param priceIdentifier UMA price identifier.
-    /// @param requestRules Raw UMA request rules.
-    /// @return Request-rules update history.
-    function getRequestRulesUpdates(bytes32 priceIdentifier, bytes calldata requestRules)
-        external
-        view
-        returns (RequestRulesUpdate[] memory);
-
-    /// @notice Returns the latest request-rules update posted for a UMA request identity.
-    /// @param priceIdentifier UMA price identifier.
-    /// @param requestRules Raw UMA request rules.
-    /// @return Latest request-rules update.
-    function getLatestRequestRulesUpdate(bytes32 priceIdentifier, bytes calldata requestRules)
-        external
-        view
-        returns (RequestRulesUpdate memory);
 
     /// @notice Claims a Managed OO deferred reward payout owed to this reporter.
     /// @param repaymentAddress Address to receive the claimed payout.

--- a/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
@@ -109,6 +109,13 @@ interface IOptimisticOracleV2 {
         bool callbackOnPriceSettled
     ) external;
 
+    /// @notice Records a request rules update against the request identified by the caller, identifier, and rules.
+    /// @dev Keyed without a timestamp, so it applies before initialization and across re-requests.
+    /// @param identifier Price identifier to identify the existing request.
+    /// @param requestRules Request rules of the price being requested.
+    /// @param updatedRules Updated request rules to record for the request.
+    function updateRequestRules(bytes32 identifier, bytes memory requestRules, bytes memory updatedRules) external;
+
     /// @notice Gets current request data for an OO request tuple.
     /// @param requester Sender of the initial price request.
     /// @param identifier Price identifier to identify the existing request.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -2,13 +2,7 @@
 pragma solidity 0.8.34;
 
 import {OOReporter} from "src/OOReporter.sol";
-import {
-    IOOReporter,
-    RequestData,
-    RequestRulesUpdate,
-    RerequestTrigger,
-    RerequestType
-} from "src/interfaces/IOOReporter.sol";
+import {IOOReporter, RequestData, RerequestTrigger, RerequestType} from "src/interfaces/IOOReporter.sol";
 import {MockERC20} from "test/mocks/MockERC20.sol";
 import {MockOptimisticOracleV2} from "test/mocks/MockOptimisticOracleV2.sol";
 
@@ -348,7 +342,7 @@ contract OOReporterTest {
         reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MINIMUM_LIVENESS);
     }
 
-    function test_updateRequestRulesStoresAndReadsByRequestIdAndTuple() external {
+    function test_updateRequestRulesForwardsToOptimisticOracle() external {
         bytes memory requestRules = _requestRules("primary");
         bytes memory firstUpdatedRules = bytes("first rules update");
         bytes memory secondUpdatedRules = bytes("second rules update");
@@ -367,22 +361,14 @@ contract OOReporterTest {
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         assertEq(request.requester, requester, "stored requester mismatch");
 
-        RequestRulesUpdate[] memory updates = reporter.getRequestRulesUpdates(REQUEST_ID);
-        assertEq(updates.length, 2, "request rules update count mismatch");
-        assertEq(updates[0].updatedRules, firstUpdatedRules, "first rules update mismatch");
-        assertEq(updates[1].updatedRules, secondUpdatedRules, "second rules update mismatch");
-
-        RequestRulesUpdate memory latest = reporter.getLatestRequestRulesUpdate(REQUEST_ID);
-        assertEq(latest.timestamp, block.timestamp, "latest timestamp mismatch");
-        assertEq(latest.updatedRules, secondUpdatedRules, "latest rules update mismatch");
-
-        RequestRulesUpdate[] memory tupleRulesUpdates = reporter.getRequestRulesUpdates(BINARY_IDENTIFIER, requestRules);
-        assertEq(tupleRulesUpdates.length, 2, "tuple update count mismatch");
-        assertEq(tupleRulesUpdates[1].updatedRules, secondUpdatedRules, "tuple latest list mismatch");
-
-        RequestRulesUpdate memory tupleRulesLatest =
-            reporter.getLatestRequestRulesUpdate(BINARY_IDENTIFIER, requestRules);
-        assertEq(tupleRulesLatest.updatedRules, secondUpdatedRules, "tuple latest mismatch");
+        // The reporter does not store rules updates; it forwards them to the Managed OO keyed by its own address as
+        // the requester, the price identifier, and the original request rules.
+        MockOptimisticOracleV2.ForwardedRulesUpdate[] memory forwarded =
+            optimisticOracle.getForwardedRulesUpdates(address(reporter), BINARY_IDENTIFIER, requestRules);
+        assertEq(forwarded.length, 2, "forwarded update count mismatch");
+        assertEq(forwarded[0].updatedRules, firstUpdatedRules, "first forwarded rules mismatch");
+        assertEq(forwarded[1].updatedRules, secondUpdatedRules, "second forwarded rules mismatch");
+        assertEq(forwarded[1].timestamp, block.timestamp, "latest forwarded timestamp mismatch");
     }
 
     function test_updateRequestRulesRejectsUnknownAndWrongRequester() external {
@@ -438,9 +424,6 @@ contract OOReporterTest {
 
         vm.expectRevert(IOOReporter.RequestResolutionUnavailable.selector);
         reporter.getRequestResolution(REQUEST_ID);
-
-        vm.expectRevert(IOOReporter.RequestRulesUpdateUnavailable.selector);
-        reporter.getLatestRequestRulesUpdate(REQUEST_ID);
     }
 
     function test_priceSettledStoresRawBinaryPrices() external {

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -21,7 +21,13 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         int256 price;
     }
 
+    struct ForwardedRulesUpdate {
+        uint256 timestamp;
+        bytes updatedRules;
+    }
+
     mapping(bytes32 requestKey => MockRequest request) public requests;
+    mapping(bytes32 rulesKey => ForwardedRulesUpdate[] updates) public forwardedRulesUpdates;
     mapping(IERC20 currency => mapping(address deferredRecipient => uint256 amount)) public deferredPayouts;
     uint256 public minimumDisputeWindow = 5 minutes;
     bool public deferNextDisputeRefund;
@@ -125,6 +131,23 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         require(customLiveness < 5200 weeks, "liveness too long");
 
         requests[requestKey(msg.sender, identifier, timestamp, requestRules)].customLiveness = customLiveness;
+    }
+
+    function updateRequestRules(bytes32 identifier, bytes memory requestRules, bytes memory updatedRules) external {
+        bytes32 key = rulesKey(msg.sender, identifier, requestRules);
+        forwardedRulesUpdates[key].push(ForwardedRulesUpdate({timestamp: block.timestamp, updatedRules: updatedRules}));
+    }
+
+    function rulesKey(address requester, bytes32 identifier, bytes memory requestRules) public pure returns (bytes32) {
+        return keccak256(abi.encode(requester, identifier, requestRules));
+    }
+
+    function getForwardedRulesUpdates(address requester, bytes32 identifier, bytes memory requestRules)
+        external
+        view
+        returns (ForwardedRulesUpdate[] memory)
+    {
+        return forwardedRulesUpdates[rulesKey(requester, identifier, requestRules)];
     }
 
     function disputePrice(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)

--- a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
@@ -37,6 +37,11 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
         bool isSet;
     }
 
+    struct RequestRulesUpdate {
+        uint256 timestamp;
+        bytes updatedRules;
+    }
+
     // Config admin role is used to manage request managers and set other default parameters.
     bytes32 public constant CONFIG_ADMIN_ROLE = keccak256("CONFIG_ADMIN_ROLE");
 
@@ -72,6 +77,9 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     // Admin controlled minimum dispute window, enforced in early resolutions and setting custom liveness.
     /// @custom:oz-renamed-from minimumLiveness
     uint256 public minimumDisputeWindow;
+
+    // Request rules update history posted by requesters for specific requests.
+    mapping(bytes32 managedRequestId => RequestRulesUpdate[] updates) public requestRulesUpdates;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -338,6 +346,27 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     }
 
     /**
+     * @notice Posts updated request rules for a request made by the caller.
+     * @dev Records the update against the caller's managed request id, so it can be posted before the request exists
+     * (pre-configuration) or after, and a single history applies across re-requests that reuse the same ancillary
+     * data. Restricted to whitelisted requesters to prevent unbounded storage growth from arbitrary callers.
+     * @param identifier price identifier to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param updatedRules updated request rules to record for the request.
+     */
+    function updateRequestRules(bytes32 identifier, bytes memory ancillaryData, bytes memory updatedRules)
+        external
+        nonReentrant
+    {
+        require(requesterWhitelist.isOnWhitelist(msg.sender), RequesterNotWhitelisted());
+        bytes32 managedRequestId = getManagedRequestId(msg.sender, identifier, ancillaryData);
+        requestRulesUpdates[managedRequestId].push(
+            RequestRulesUpdate({timestamp: block.timestamp, updatedRules: updatedRules})
+        );
+        emit RequestRulesUpdated(managedRequestId, msg.sender, identifier, ancillaryData, updatedRules);
+    }
+
+    /**
      * @notice Proposes a price value on another address' behalf. Note: this address will receive any rewards that come
      * from this proposal. However, any bonds are pulled from the caller.
      * @dev Applies any pre-configured Request Manager settings (bond, liveness, whitelist) before calling parent
@@ -476,6 +505,43 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     }
 
     /**
+     * @notice Returns all request rules updates posted for a request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return the full request rules update history.
+     */
+    function getRequestRulesUpdates(address requester, bytes32 identifier, bytes memory ancillaryData)
+        external
+        view
+        nonReentrantView
+        returns (RequestRulesUpdate[] memory)
+    {
+        return requestRulesUpdates[getManagedRequestId(requester, identifier, ancillaryData)];
+    }
+
+    /**
+     * @notice Returns the latest request rules update posted for a request.
+     * @dev Reverts if no update has been posted for the request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return the latest request rules update.
+     */
+    function getLatestRequestRulesUpdate(address requester, bytes32 identifier, bytes memory ancillaryData)
+        external
+        view
+        nonReentrantView
+        returns (RequestRulesUpdate memory)
+    {
+        RequestRulesUpdate[] storage updates =
+            requestRulesUpdates[getManagedRequestId(requester, identifier, ancillaryData)];
+        uint256 updateCount = updates.length;
+        require(updateCount != 0, RequestRulesUpdateUnavailable());
+        return updates[updateCount - 1];
+    }
+
+    /**
      * @notice Sets the bounds for a bond that can be set for a request.
      * @dev This can be used to limit the bond amount that can be set by request managers. Setting the minimum and
      * maximum both to 0 effectively blocks the request manager from overriding the bond for a given currency.
@@ -609,5 +675,5 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
      * bottom of contract to make sure its always at the end of storage.
      * See https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#storage-gaps
      */
-    uint256[993] private __gap;
+    uint256[992] private __gap;
 }

--- a/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
@@ -33,6 +33,8 @@ abstract contract ManagedOptimisticOracleV2Interface {
     error MinimumDisputeWindowTooSmall();
     /// @notice Thrown in settleAndGetPrice if the request has not been settled by resolver.
     error RequestNotSettled();
+    /// @notice Thrown when the latest request rules update is requested before any update is posted.
+    error RequestRulesUpdateUnavailable();
 
     event AllowedBondRangeUpdated(IERC20 indexed currency, uint256 newMinimumBond, uint256 newMaximumBond);
     event DefaultLivenessUpdated(uint256 newDefaultLiveness);
@@ -60,5 +62,12 @@ abstract contract ManagedOptimisticOracleV2Interface {
         bytes32 indexed identifier,
         bytes ancillaryData,
         address indexed newWhitelist
+    );
+    event RequestRulesUpdated(
+        bytes32 indexed managedRequestId,
+        address requester,
+        bytes32 indexed identifier,
+        bytes ancillaryData,
+        bytes updatedRules
     );
 }

--- a/test/DeferredPayout.t.sol
+++ b/test/DeferredPayout.t.sol
@@ -145,8 +145,10 @@ contract DeferredPayoutTest is Test {
         vm.stopPrank();
     }
 
+    // Read current time via oo.getCurrentTime() rather than block.timestamp to protect from via-ir reorderings (that
+    // will break the tests).
     function _makeRequest(IERC20 currency) internal returns (uint256 timestamp) {
-        timestamp = block.timestamp;
+        timestamp = oo.getCurrentTime();
         vm.prank(requester);
         oo.requestPrice(IDENTIFIER, timestamp, ANCILLARY_DATA, currency, REWARD);
     }
@@ -171,7 +173,7 @@ contract DeferredPayoutTest is Test {
         blacklistToken.setBlacklisted(proposer, true);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed but payout should be accrued
         uint256 proposerBalanceBefore = blacklistToken.balanceOf(proposer);
@@ -228,7 +230,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -260,7 +262,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -294,7 +296,7 @@ contract DeferredPayoutTest is Test {
         revertingReasonToken.setBlacklisted(proposer, true);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed but payout should be accrued
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -312,7 +314,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         revertingReasonToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -343,7 +345,7 @@ contract DeferredPayoutTest is Test {
         revertingToken.setBlacklisted(proposer, true);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed but payout should be accrued
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -361,7 +363,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         revertingToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -389,14 +391,14 @@ contract DeferredPayoutTest is Test {
         uint256 timestamp1 = _makeRequest(blacklistToken);
         _proposePrice(timestamp1, 100);
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp1, ANCILLARY_DATA);
 
         // Test with reverting token
         uint256 timestamp2 = _makeRequest(revertingReasonToken);
         _proposePrice(timestamp2, 200);
         revertingReasonToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp2, ANCILLARY_DATA);
 
         // Check both deferred payouts
@@ -423,7 +425,7 @@ contract DeferredPayoutTest is Test {
         uint256 timestamp1 = _makeRequest(blacklistToken);
         _proposePrice(timestamp1, 100);
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp1, ANCILLARY_DATA);
 
         // Second request - disputer gets blacklisted
@@ -467,7 +469,7 @@ contract DeferredPayoutTest is Test {
         _proposePrice(timestamp, 100);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed and payout should go directly to proposer
         uint256 proposerBalanceBefore = blacklistToken.balanceOf(proposer);
@@ -547,7 +549,7 @@ contract DeferredPayoutTest is Test {
         _proposePrice(timestamp, 100);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed and payout should go directly to proposer
         uint256 proposerBalanceBefore = revertingReasonToken.balanceOf(proposer);
@@ -569,7 +571,7 @@ contract DeferredPayoutTest is Test {
         _proposePrice(timestamp, 100);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed and payout should go directly to proposer
         uint256 proposerBalanceBefore = revertingToken.balanceOf(proposer);
@@ -597,7 +599,7 @@ contract DeferredPayoutTest is Test {
         _proposePrice(timestamp, 100);
 
         // Fast forward to expiration
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Settlement should succeed and payout should go directly to proposer
         uint256 proposerBalanceBefore = blacklistToken.balanceOf(proposer);
@@ -638,7 +640,7 @@ contract DeferredPayoutTest is Test {
         uint256 timestamp = _makeRequest(blacklistToken);
         _proposePrice(timestamp, 100);
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         // Try to claim payout with zero address as repayment address
@@ -652,7 +654,7 @@ contract DeferredPayoutTest is Test {
         uint256 timestamp1 = _makeRequest(blacklistToken);
         _proposePrice(timestamp1, 100);
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         vm.prank(requester);
         oo.settle(requester, IDENTIFIER, timestamp1, ANCILLARY_DATA);
 
@@ -667,7 +669,7 @@ contract DeferredPayoutTest is Test {
         _proposePrice(timestamp2, 200);
         // Blacklist proposer again before settlement
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp2, ANCILLARY_DATA);
 
         uint256 secondAccrued = oo.deferredPayouts(blacklistToken, proposer);
@@ -687,7 +689,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
 
         // Expect the PayoutDeferred event
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -702,7 +704,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 accruedAmount = oo.deferredPayouts(blacklistToken, proposer);
@@ -730,7 +732,7 @@ contract DeferredPayoutTest is Test {
         blacklistToken.setBlacklisted(proposer, true);
 
         // 3. Settle (should accrue payout)
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         uint256 expectedPayout = TOTAL_BOND + REWARD;
@@ -764,7 +766,7 @@ contract DeferredPayoutTest is Test {
 
         // Blacklist proposer and settle
         blacklistToken.setBlacklisted(proposer, true);
-        vm.warp(block.timestamp + LIVENESS + 1);
+        vm.warp(oo.getCurrentTime() + LIVENESS + 1);
         oo.settle(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
 
         // Check deferred payout includes custom bond + final fee + reward

--- a/test/ManagedOptimisticOracleV2.Fork.t.sol
+++ b/test/ManagedOptimisticOracleV2.Fork.t.sol
@@ -273,20 +273,22 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         console.log("  Bond Amount:", bondAmount);
         console.log("  Token: USDC.e", address(USDC_E));
 
-        // Request price and opt-in for early resolution
+        // Request price and opt-in for early resolution. Capture the request timestamp via getCurrentTime() rather
+        // than block.timestamp to protect from via-ir reorderings (that will break the tests).
+        uint256 requestTimestamp = managedOOv2.getCurrentTime();
         vm.startPrank(requester);
         USDC_E.approve(address(managedOOv2), type(uint256).max);
 
         managedOOv2.requestPrice(
             TEST_IDENTIFIER,
-            block.timestamp,
+            requestTimestamp,
             ancillaryData,
             USDC_E,
             0 // no reward
         );
         console.log("  + Price request created");
         uint256 customLiveness = 5 minutes;
-        managedOOv2.setCustomLiveness(TEST_IDENTIFIER, block.timestamp, ancillaryData, customLiveness);
+        managedOOv2.setCustomLiveness(TEST_IDENTIFIER, requestTimestamp, ancillaryData, customLiveness);
         vm.stopPrank();
 
         // Propose price
@@ -297,7 +299,7 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
             proposer,
             requester,
             TEST_IDENTIFIER,
-            block.timestamp,
+            requestTimestamp,
             ancillaryData,
             1e18 // proposed price: YES
         );
@@ -305,11 +307,11 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         vm.stopPrank();
 
         // Wait for minimum dispute window
-        vm.warp(block.timestamp + customLiveness + 1);
+        vm.warp(requestTimestamp + customLiveness + 1);
 
         // Resolver settles early
         vm.prank(resolver);
-        managedOOv2.settle(requester, TEST_IDENTIFIER, block.timestamp - customLiveness - 1, ancillaryData);
+        managedOOv2.settle(requester, TEST_IDENTIFIER, requestTimestamp, ancillaryData);
         console.log("  + Resolver settled after minimum dispute window");
     }
 
@@ -320,10 +322,10 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         console.log("\n=== Testing Extended Dispute Window ===");
 
         // Setup: Create a price request and proposal
-        _setupPriceRequestAndProposal();
+        uint256 requestTimestamp = _setupPriceRequestAndProposal();
 
         // Warp past expiration (default liveness is 5 minutes after upgrade)
-        vm.warp(block.timestamp + 6 minutes);
+        vm.warp(requestTimestamp + 6 minutes);
 
         console.log("  Time after proposal: 6 minutes (past expiration)");
 
@@ -337,7 +339,7 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         USDC_E.approve(address(managedOOv2), type(uint256).max);
 
         // Dispute should work even though expired because of _getStateForDispute override
-        managedOOv2.disputePriceFor(disputer, requester, TEST_IDENTIFIER, block.timestamp - 6 minutes, ancillaryData);
+        managedOOv2.disputePriceFor(disputer, requester, TEST_IDENTIFIER, requestTimestamp, ancillaryData);
         console.log("  + Dispute succeeded even after expiration");
         console.log("  This proves extended dispute window works!");
         vm.stopPrank();
@@ -350,17 +352,17 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         console.log("\n=== Testing Non-Resolver Cannot Settle Early ===");
 
         // Setup: Create a price request and proposal
-        _setupPriceRequestAndProposal();
+        uint256 requestTimestamp = _setupPriceRequestAndProposal();
 
         // Wait for minimum dispute window
-        vm.warp(block.timestamp + 5 minutes + 1);
+        vm.warp(requestTimestamp + 5 minutes + 1);
 
         // Try to settle as non-resolver (should fail)
         address nonResolver = makeAddr("nonResolver");
         vm.prank(nonResolver);
 
         vm.expectRevert();
-        managedOOv2.settle(requester, TEST_IDENTIFIER, block.timestamp - 5 minutes - 1, ancillaryData);
+        managedOOv2.settle(requester, TEST_IDENTIFIER, requestTimestamp, ancillaryData);
 
         console.log("  + Non-resolver cannot settle (correctly reverted)");
     }
@@ -402,7 +404,7 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         vm.stopPrank();
     }
 
-    function _setupPriceRequestAndProposal() internal {
+    function _setupPriceRequestAndProposal() internal returns (uint256 requestTimestamp) {
         // Setup roles - grant resolver admin role and add resolver
         vm.startPrank(upgradeAdmin);
         managedOOv2.grantRole(managedOOv2.RESOLVER_ADMIN_ROLE(), upgradeAdmin);
@@ -431,18 +433,20 @@ contract ManagedOptimisticOracleV2ForkTest is Test {
         deal(address(USDC_E), requester, 1000e6);
         deal(address(USDC_E), proposer, 1000e6);
 
-        // Create request
+        // Create request. Capture the request timestamp via getCurrentTime() rather than block.timestamp to protect
+        // from via-ir reorderings (that will break the tests).
+        requestTimestamp = managedOOv2.getCurrentTime();
         vm.startPrank(requester);
         USDC_E.approve(address(managedOOv2), type(uint256).max);
 
-        managedOOv2.requestPrice(TEST_IDENTIFIER, block.timestamp, ancillaryData, USDC_E, 0);
+        managedOOv2.requestPrice(TEST_IDENTIFIER, requestTimestamp, ancillaryData, USDC_E, 0);
         vm.stopPrank();
 
         // Propose price
         vm.startPrank(proposer);
         USDC_E.approve(address(managedOOv2), type(uint256).max);
 
-        managedOOv2.proposePriceFor(proposer, requester, TEST_IDENTIFIER, block.timestamp, ancillaryData, 1e18);
+        managedOOv2.proposePriceFor(proposer, requester, TEST_IDENTIFIER, requestTimestamp, ancillaryData, 1e18);
         vm.stopPrank();
     }
 }

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -162,6 +162,9 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.addResolver(resolver);
     }
 
+    // Read current time via moo.getCurrentTime() rather than block.timestamp to protect from via-ir reorderings (that
+    // will break the tests).
+
     function _makeRequest(address _requester, uint256 _timestamp, uint256 reward)
         internal
         returns (uint256 totalBond)
@@ -214,8 +217,9 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(list.length, 2);
 
         // requester whitelist enforced
+        uint256 nowTs = moo.getCurrentTime();
         vm.expectRevert(ManagedOptimisticOracleV2Interface.RequesterNotWhitelisted.selector);
-        moo.requestPrice(IDENTIFIER, block.timestamp, ANCILLARY, IERC20(address(currency)), 0);
+        moo.requestPrice(IDENTIFIER, nowTs, ANCILLARY, IERC20(address(currency)), 0);
 
         // role admin configuration
         bytes32 CONFIG_ADMIN_ROLE = moo.CONFIG_ADMIN_ROLE();
@@ -364,11 +368,12 @@ contract ManagedOptimisticOracleV2Test is Test {
 
     function testRequesterWhitelistEnforcedOnRequestPrice() external {
         // Non-whitelisted requester -> revert
+        uint256 nowTs = moo.getCurrentTime();
         vm.expectRevert(ManagedOptimisticOracleV2Interface.RequesterNotWhitelisted.selector);
-        moo.requestPrice(IDENTIFIER, block.timestamp, ANCILLARY, IERC20(address(currency)), 0);
+        moo.requestPrice(IDENTIFIER, nowTs, ANCILLARY, IERC20(address(currency)), 0);
 
         // Whitelisted requester -> ok
-        uint256 totalBond = _makeRequest(requester, block.timestamp, 0);
+        uint256 totalBond = _makeRequest(requester, moo.getCurrentTime(), 0);
         // finalFee is 10 ether; initial bond = finalFee*2 per base contract
         assertEq(totalBond, 20 ether);
     }
@@ -403,7 +408,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     // -------------------- Propose Access Control --------------------
 
     function testProposePriceForChecksDefaultWhitelist() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Valid proposer and sender in default whitelist
@@ -412,7 +417,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
         // Invalid proposer: create a new request for t+1 and use non-whitelisted proposer
         vm.warp(t + 1);
-        _makeRequest(requester, block.timestamp, 0);
+        _makeRequest(requester, moo.getCurrentTime(), 0);
         _prepareFunds(sender);
         vm.expectRevert(ManagedOptimisticOracleV2Interface.ProposerNotWhitelisted.selector);
         vm.prank(sender);
@@ -420,7 +425,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
         // Invalid sender
         vm.warp(t + 2);
-        _makeRequest(requester, block.timestamp, 0);
+        _makeRequest(requester, moo.getCurrentTime(), 0);
         _prepareFunds(otherSender);
         vm.expectRevert(ManagedOptimisticOracleV2Interface.SenderNotWhitelisted.selector);
         vm.prank(otherSender);
@@ -428,7 +433,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testProposePriceForWithCustomDisabledWhitelist() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Set disabled custom whitelist for this request
@@ -445,7 +450,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     // -------------------- Settle Flow Tests -------------------------
 
     function testNonResolverCannotSettle() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         _proposeFor(sender, proposer, requester, t, 42);
@@ -463,7 +468,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testResolverCannotSettleBeforeExpiration() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         _proposeFor(sender, proposer, requester, t, 42);
@@ -477,7 +482,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testResolverCanSettleAfterExpiration() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         int256 price = 42;
         _makeRequest(requester, t, 0);
 
@@ -497,7 +502,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testNoExpiredState() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         _proposeFor(sender, proposer, requester, t, 42);
@@ -574,7 +579,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testCustomBondAppliedOnPropose() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Set custom bond of 5 ether
@@ -652,7 +657,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.setDefaultLiveness(newDefaultLiveness);
 
         // Create a request without custom liveness
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Propose and check that new default liveness is applied
@@ -660,7 +665,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         _proposeFor(sender, proposer, requester, t, 123);
 
         OptimisticOracleV2Interface.Request memory req = moo.getRequest(requester, IDENTIFIER, t, ANCILLARY);
-        assertEq(req.expirationTime, block.timestamp + newDefaultLiveness);
+        assertEq(req.expirationTime, moo.getCurrentTime() + newDefaultLiveness);
     }
 
     function testSetDefaultLivenessRequiresLoweringMinimumDisputeWindowFirst() external {
@@ -684,7 +689,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testRequestManagerSetCustomLivenessValidationAndEffect() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Below minimum -> revert
@@ -708,11 +713,11 @@ contract ManagedOptimisticOracleV2Test is Test {
         vm.warp(t + 10);
         _proposeFor(sender, proposer, requester, t, 123);
         OptimisticOracleV2Interface.Request memory req = moo.getRequest(requester, IDENTIFIER, t, ANCILLARY);
-        assertEq(req.expirationTime, block.timestamp + 3 hours);
+        assertEq(req.expirationTime, moo.getCurrentTime() + 3 hours);
     }
 
     function testRequesterSetCustomLivenessValidation() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Below minimum -> revert
@@ -733,7 +738,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         vm.warp(t + 10);
         _proposeFor(sender, proposer, requester, t, 123);
         OptimisticOracleV2Interface.Request memory req = moo.getRequest(requester, IDENTIFIER, t, ANCILLARY);
-        assertEq(req.expirationTime, block.timestamp + MINIMUM_DISPUTE_WINDOW);
+        assertEq(req.expirationTime, moo.getCurrentTime() + MINIMUM_DISPUTE_WINDOW);
     }
 
     // -------------------- Utility --------------------
@@ -758,7 +763,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         vm.prank(requester);
         moo.updateRequestRules(IDENTIFIER, ANCILLARY, firstRules);
 
-        vm.warp(block.timestamp + 10);
+        vm.warp(moo.getCurrentTime() + 10);
         vm.prank(requester);
         moo.updateRequestRules(IDENTIFIER, ANCILLARY, secondRules);
 
@@ -770,7 +775,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
         ManagedOptimisticOracleV2.RequestRulesUpdate memory latest =
             moo.getLatestRequestRulesUpdate(requester, IDENTIFIER, ANCILLARY);
-        assertEq(latest.timestamp, block.timestamp);
+        assertEq(latest.timestamp, moo.getCurrentTime());
         assertEq(latest.updatedRules, secondRules);
     }
 
@@ -930,7 +935,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testResetCustomProposerWhitelistToDefault() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
         // Disable whitelist per-request
@@ -992,7 +997,7 @@ contract ManagedOptimisticOracleV2Test is Test {
     }
 
     function testOracleRequestTimeEventBasedDispute() external {
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
         vm.prank(requester);
         moo.setEventBased(IDENTIFIER, t, ANCILLARY);
@@ -1014,7 +1019,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
     function testMulticallPreservesCustomErrors() external {
         // Test that multicall properly bubbles custom errors instead of corrupting them
-        uint256 t = block.timestamp;
+        uint256 t = moo.getCurrentTime();
 
         // Create a multicall that should revert with RequesterNotWhitelisted()
         bytes[] memory calls = new bytes[](1);

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -744,6 +744,58 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(id1, id2);
     }
 
+    // -------------------- Request Rules Updates --------------------
+
+    function testUpdateRequestRulesStoresAndEmits() external {
+        bytes memory firstRules = bytes("first rules update");
+        bytes memory secondRules = bytes("second rules update");
+        bytes32 managedId = moo.getManagedRequestId(requester, IDENTIFIER, ANCILLARY);
+
+        vm.expectEmit(true, true, false, true);
+        emit ManagedOptimisticOracleV2Interface.RequestRulesUpdated(
+            managedId, requester, IDENTIFIER, ANCILLARY, firstRules
+        );
+        vm.prank(requester);
+        moo.updateRequestRules(IDENTIFIER, ANCILLARY, firstRules);
+
+        vm.warp(block.timestamp + 10);
+        vm.prank(requester);
+        moo.updateRequestRules(IDENTIFIER, ANCILLARY, secondRules);
+
+        ManagedOptimisticOracleV2.RequestRulesUpdate[] memory updates =
+            moo.getRequestRulesUpdates(requester, IDENTIFIER, ANCILLARY);
+        assertEq(updates.length, 2);
+        assertEq(updates[0].updatedRules, firstRules);
+        assertEq(updates[1].updatedRules, secondRules);
+
+        ManagedOptimisticOracleV2.RequestRulesUpdate memory latest =
+            moo.getLatestRequestRulesUpdate(requester, IDENTIFIER, ANCILLARY);
+        assertEq(latest.timestamp, block.timestamp);
+        assertEq(latest.updatedRules, secondRules);
+    }
+
+    function testUpdateRequestRulesAllowedBeforeRequestExists() external {
+        // No requestPrice has been made yet; like other manager settings, updates may be pre-configured.
+        bytes memory rules = bytes("pre-config rules");
+        vm.prank(requester);
+        moo.updateRequestRules(IDENTIFIER, ANCILLARY, rules);
+
+        ManagedOptimisticOracleV2.RequestRulesUpdate memory latest =
+            moo.getLatestRequestRulesUpdate(requester, IDENTIFIER, ANCILLARY);
+        assertEq(latest.updatedRules, rules);
+    }
+
+    function testUpdateRequestRulesOnlyWhitelistedRequester() external {
+        vm.prank(nonRequester);
+        vm.expectRevert(ManagedOptimisticOracleV2Interface.RequesterNotWhitelisted.selector);
+        moo.updateRequestRules(IDENTIFIER, ANCILLARY, bytes("rules"));
+    }
+
+    function testGetLatestRequestRulesUpdateRevertsWhenEmpty() external {
+        vm.expectRevert(ManagedOptimisticOracleV2Interface.RequestRulesUpdateUnavailable.selector);
+        moo.getLatestRequestRulesUpdate(requester, IDENTIFIER, ANCILLARY);
+    }
+
     // -------------------- Ownership / Control Relationships --------------------
 
     function testRolesAndOwnershipRelations() external view {


### PR DESCRIPTION
Relocates request-rules update recording from the `OOReporter` to the `ManagedOptimisticOracleV2`, so updates live alongside the request and become part of the canonical on-chain store and event source the broader UMA ecosystem already watches.

- Adds `updateRequestRules(identifier, ancillaryData, updatedRules)` to the Managed OO — gated by the existing `requesterWhitelist`, keyed by `managedRequestId` (no timestamp), storing history and emitting a new `RequestRulesUpdated` event. Includes `getRequestRulesUpdates` / `getLatestRequestRulesUpdate` getters and a `RequestRulesUpdateUnavailable` error. Storage is append-only (`__gap` 993 → 992).
- The reporter's `updateRequestRules` keeps its exact signature and access rules but now forwards to the OO instead of storing; its recording surface (storage, getters, struct, error) is removed.
