### PR TITLE
fix[oz-retainer-07-m-02]: remove OOReporter runtime liveness cap

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -44,7 +44,8 @@ domain-separate request rules so their UMA request identities differ.
 - requester/module allowlisting;
 - UMA oracle initializer allowlisting;
 - Managed OO request creation;
-- reward, bond, request-specific liveness bounds, automatic re-request controls, and manual re-request budget controls;
+- reward, bond, request-specific liveness minimums and target maximums, automatic re-request controls, and manual
+  re-request budget controls;
 - forwarding request rules updates to the Managed OO for active requests;
 - raw UMA settlement storage.
 
@@ -57,18 +58,23 @@ The prediction market integration owns:
 ## Request Lifecycle
 
 An enabled requester first calls `registerRequest(...)` with its external `requestId`, UMA price identifier, raw request
-rules, and allowed liveness range. The reporter reserves the `(priceIdentifier, requestRules)` tuple globally within
-the deployment so two request IDs cannot point at the same UMA request identity.
+rules, and liveness range. Registration requires an internally consistent range that overlaps the Managed OO bounds at
+that time. The minimum remains an onchain floor, while the maximum is stored, returned, and emitted as an offchain
+initialization target rather than an onchain ceiling. The reporter reserves the `(priceIdentifier, requestRules)` tuple
+globally within the deployment so two request IDs cannot point at the same UMA request identity.
 
 An enabled UMA oracle initializer later calls `initializeRequest(requestId, reward, proposalBond, liveness)`. The selected
-liveness must be non-zero and inside the registered range. Each initialized request receives the current
-`defaultRerequestBudget` as its manual re-request budget.
+liveness must be non-zero and at or above the registered minimum, but it may exceed the registered target maximum. The
+Managed OO independently enforces its current `minimumDisputeWindow` and technical maximum. Each initialized request
+receives the current `defaultRerequestBudget` as its manual re-request budget.
 
 Automatic re-requests are enabled by default and can be disabled or re-enabled by the owner with
 `setAutomaticRerequestsEnabled(...)`. The current setting is evaluated when a dispute or P4 settlement callback arrives,
 not when the request was initialized or last re-requested. When enabled, the first dispute callback for a request
 attempts one replacement without consuming manual re-request budget. Failed attempts and later dispute callbacks open
-the manual re-request gate without reverting the dispute.
+the manual re-request gate without reverting the dispute. If Managed OO configuration drift invalidates the active
+liveness, an automatic replacement can fail and an enabled oracle initializer can recover manually with a valid
+liveness above the registered target maximum.
 
 P4 settlements intentionally reset the active request's manual budget to the current default. When automatic re-requests
 are enabled, P4 settlements also attempt a replacement without consuming manual budget. Disabled or failed attempts open

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -536,10 +536,10 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         oracle.setCustomLiveness(priceIdentifier, requestTimestamp, requestRules, liveness);
     }
 
-    /// @dev Keeps the reporter off Managed OO's default liveness path and within the registered bounds.
+    /// @dev Keeps the reporter off Managed OO's default liveness path and above the registered minimum.
     function _requireValidRequestLiveness(RequestData storage request, uint64 liveness) private view {
         if (liveness == 0) revert RequestLivenessCannotBeZero();
-        if (liveness < request.minimumLiveness || liveness > request.maximumLiveness) {
+        if (liveness < request.minimumLiveness) {
             revert RequestLivenessOutOfRange(liveness, request.minimumLiveness, request.maximumLiveness);
         }
     }

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -36,9 +36,9 @@ struct RequestData {
     /// @dev Seeded from the default at initialization, owner-adjustable, and intentionally refreshed to the default after
     /// DVM-resolved P4 settlements so UMA-controlled oracle initializers can keep recovery moving.
     uint256 manualRerequestsRemaining;
-    /// @notice Minimum liveness UMA is allowed to use for this request.
+    /// @notice Minimum custom liveness enforced by the reporter for this request.
     uint64 minimumLiveness;
-    /// @notice Maximum liveness UMA is allowed to use for this request.
+    /// @notice Target maximum custom liveness for offchain initializers, not an onchain runtime ceiling.
     uint64 maximumLiveness;
 }
 
@@ -120,7 +120,7 @@ interface IOOReporter {
     );
     /// @notice Thrown when the oracle initializer tries to use the Managed OO default liveness path.
     error RequestLivenessCannotBeZero();
-    /// @notice Thrown when selected liveness is outside the registered bounds.
+    /// @notice Thrown when selected liveness is below the registered minimum.
     error RequestLivenessOutOfRange(uint64 liveness, uint64 minimumLiveness, uint64 maximumLiveness);
     /// @notice Thrown when a final reporter outcome is requested before one is available.
     error RequestResolutionUnavailable();
@@ -262,13 +262,13 @@ interface IOOReporter {
     /// Enabled requesters share one owner-managed request namespace; the contract does not isolate identical UMA
     /// request identities per requester. Independent integrations that need the exact same UMA request identity should
     /// use separate reporter deployments; integrations with similar rules can domain-separate request rules so their
-    /// UMA request identities differ. Requesters should preserve an admin recovery path for rules or liveness ranges
-    /// that become unusable before initialization.
+    /// UMA request identities differ. minimumLiveness is enforced as an onchain runtime floor, while maximumLiveness
+    /// remains a registration-time bound and offchain target that does not cap initialization or re-requests.
     /// @param requestId Requester-defined request ID to bind to the UMA request identity.
     /// @param priceIdentifier UMA price identifier to request.
     /// @param requestRules Raw UMA request rules supplied by the requester.
     /// @param minimumLiveness Minimum custom liveness the oracle initializer may use.
-    /// @param maximumLiveness Maximum custom liveness the oracle initializer may use.
+    /// @param maximumLiveness Target maximum custom liveness for offchain initialization.
     function registerRequest(
         bytes32 requestId,
         bytes32 priceIdentifier,
@@ -290,8 +290,9 @@ interface IOOReporter {
     /// @param reward Reward offered to a successful OO proposer.
     /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective
     /// proposal bond can differ if Managed OO request-manager preconfigs apply at proposal time.
-    /// @param liveness Custom OO liveness period within the registered bounds. The effective proposal liveness can
-    /// differ if Managed OO request-manager preconfigs apply at proposal time.
+    /// @param liveness Custom OO liveness period at or above the registered minimum. It may exceed the registered
+    /// target maximum and remains subject to Managed OO constraints. The effective proposal liveness can differ if
+    /// Managed OO request-manager preconfigs apply at proposal time.
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Allows an enabled oracle initializer to create a replacement Managed OO request after a callback opens the gate.
@@ -299,8 +300,9 @@ interface IOOReporter {
     /// @param reward Reward amount for the replacement request.
     /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective
     /// proposal bond can differ if Managed OO request-manager preconfigs apply at proposal time.
-    /// @param liveness Custom OO liveness period within the registered bounds. The effective proposal liveness can
-    /// differ if Managed OO request-manager preconfigs apply at proposal time.
+    /// @param liveness Custom OO liveness period at or above the registered minimum. It may exceed the registered
+    /// target maximum and remains subject to Managed OO constraints. The effective proposal liveness can differ if
+    /// Managed OO request-manager preconfigs apply at proposal time.
     function rerequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Updates the remaining manual re-request budget for an initialized unresolved request.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -313,7 +313,7 @@ contract OOReporterTest {
         reporter.initializeRequest(REQUEST_ID, 0, 0, 0);
     }
 
-    function test_initializeRequestRejectsLivenessOutsideRegisteredRange() external {
+    function test_initializeRequestRejectsLivenessBelowRegisteredMinimum() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequestWithLivenessRange(
             REQUEST_ID, BINARY_IDENTIFIER, requestRules, STRICT_MINIMUM_LIVENESS, STRICT_MAXIMUM_LIVENESS
@@ -331,18 +331,46 @@ contract OOReporterTest {
         reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MINIMUM_LIVENESS - 1);
 
         vm.prank(oracleInitializer);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IOOReporter.RequestLivenessOutOfRange.selector,
-                STRICT_MAXIMUM_LIVENESS + 1,
-                STRICT_MINIMUM_LIVENESS,
-                STRICT_MAXIMUM_LIVENESS
-            )
+        reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MINIMUM_LIVENESS);
+    }
+
+    function test_initializeRequestAcceptsCurrentOracleMinimumAboveRegisteredMaximum() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequestWithLivenessRange(
+            REQUEST_ID, BINARY_IDENTIFIER, requestRules, STRICT_MINIMUM_LIVENESS, STRICT_MAXIMUM_LIVENESS
         );
-        reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MAXIMUM_LIVENESS + 1);
+
+        uint64 currentOracleMinimum = STRICT_MAXIMUM_LIVENESS + 1;
+        optimisticOracle.setMinimumDisputeWindow(currentOracleMinimum);
 
         vm.prank(oracleInitializer);
-        reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MINIMUM_LIVENESS);
+        reporter.initializeRequest(REQUEST_ID, 0, 0, currentOracleMinimum);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        assertEq(request.liveness, currentOracleMinimum, "selected liveness mismatch");
+        assertEq(request.maximumLiveness, STRICT_MAXIMUM_LIVENESS, "target maximum should remain stored");
+
+        bytes32 requestKey =
+            optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
+        assertEq(
+            optimisticOracle.getMockRequest(requestKey).customLiveness, currentOracleMinimum, "OO liveness mismatch"
+        );
+    }
+
+    function test_initializeRequestPreservesManagedOOLivenessBounds() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        optimisticOracle.setMinimumDisputeWindow(uint256(LIVENESS) + 1);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "liveness below minimum"));
+        reporter.initializeRequest(REQUEST_ID, 0, 0, LIVENESS);
+
+        uint64 maximumCustomLiveness = uint64(reporter.MAXIMUM_CUSTOM_LIVENESS());
+        vm.prank(oracleInitializer);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "liveness too long"));
+        reporter.initializeRequest(REQUEST_ID, 0, 0, maximumCustomLiveness);
     }
 
     function test_updateRequestRulesForwardsToOptimisticOracle() external {
@@ -489,16 +517,19 @@ contract OOReporterTest {
         reporter.executeAutomaticRerequest(REQUEST_ID, RerequestType.AutomaticDispute);
     }
 
-    function test_priceDisputedOpensManualGateWhenAutomaticRerequestReverts() external {
+    function test_priceDisputedAllowsManualRecoveryAboveRegisteredMaximumAfterConfigurationDrift() external {
         bytes memory requestRules = _requestRules("primary");
-        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+        _registerRequestWithLivenessRange(
+            REQUEST_ID, BINARY_IDENTIFIER, requestRules, STRICT_MINIMUM_LIVENESS, LIVENESS
+        );
 
         vm.prank(oracleInitializer);
         reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
 
         RequestData memory request = reporter.getRequest(REQUEST_ID);
         vm.warp(block.timestamp + 1);
-        optimisticOracle.setMinimumDisputeWindow(uint256(LIVENESS) + 1);
+        uint64 currentOracleMinimum = LIVENESS + 1;
+        optimisticOracle.setMinimumDisputeWindow(currentOracleMinimum);
 
         vm.expectEmit(address(reporter));
         emit AutomaticRerequestFailed(REQUEST_ID, request.requestTimestamp, RerequestType.AutomaticDispute);
@@ -516,6 +547,18 @@ contract OOReporterTest {
             optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
         MockOptimisticOracleV2.MockRequest memory replacementRequest = optimisticOracle.getMockRequest(replacementKey);
         assertFalse(replacementRequest.requested, "failed automatic re-request should roll back replacement request");
+
+        vm.prank(oracleInitializer);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, currentOracleMinimum);
+
+        RequestData memory recoveredRequest = reporter.getRequest(REQUEST_ID);
+        assertFalse(recoveredRequest.rerequestAllowed, "manual recovery should close gate");
+        assertEq(recoveredRequest.liveness, currentOracleMinimum, "manual recovery liveness mismatch");
+        assertEq(
+            optimisticOracle.getMockRequest(replacementKey).customLiveness,
+            currentOracleMinimum,
+            "replacement OO liveness mismatch"
+        );
     }
 
     function test_priceDisputedOpensManualGateAfterAutomaticDisputeUsed() external {
@@ -922,7 +965,7 @@ contract OOReporterTest {
         reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
     }
 
-    function test_rerequestRejectsManualLivenessOutsideRegisteredRange() external {
+    function test_rerequestRejectsManualLivenessBelowRegisteredMinimum() external {
         bytes memory requestRules = _requestRules("primary");
         _registerRequestWithLivenessRange(
             REQUEST_ID, BINARY_IDENTIFIER, requestRules, STRICT_MINIMUM_LIVENESS, STRICT_MAXIMUM_LIVENESS
@@ -942,12 +985,12 @@ contract OOReporterTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IOOReporter.RequestLivenessOutOfRange.selector,
-                STRICT_MAXIMUM_LIVENESS + 1,
+                STRICT_MINIMUM_LIVENESS - 1,
                 STRICT_MINIMUM_LIVENESS,
                 STRICT_MAXIMUM_LIVENESS
             )
         );
-        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, STRICT_MAXIMUM_LIVENESS + 1);
+        reporter.rerequest(REQUEST_ID, 0, PROPOSAL_BOND, STRICT_MINIMUM_LIVENESS - 1);
     }
 
     function test_rerequestBudgetExhaustsAndOwnerCanTopUp() external {

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -245,6 +245,29 @@ contract OOReporterTest {
         reporter.registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules, MINIMUM_LIVENESS, belowOracleMinimum);
     }
 
+    function test_initializeRequestAcceptsLivenessWithinPartiallyOverlappingRange() external {
+        bytes memory requestRules = _requestRules("primary");
+        uint64 oracleMinimumLiveness = uint64(optimisticOracle.minimumDisputeWindow());
+        uint64 oracleMaximumLiveness = uint64(reporter.MAXIMUM_CUSTOM_LIVENESS());
+
+        vm.prank(requester);
+        reporter.registerRequest(
+            REQUEST_ID, BINARY_IDENTIFIER, requestRules, oracleMinimumLiveness - 1, oracleMaximumLiveness
+        );
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, 0, oracleMinimumLiveness);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        assertEq(request.liveness, oracleMinimumLiveness, "selected liveness mismatch");
+
+        bytes32 requestKey =
+            optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
+        assertEq(
+            optimisticOracle.getMockRequest(requestKey).customLiveness, oracleMinimumLiveness, "OO liveness mismatch"
+        );
+    }
+
     function test_initializeRequestSeedsDefaultBudgetAndCreatesManagedOORequest() external {
         bytes memory requestRules = _requestRules("numerical");
         _registerRequest(REQUEST_ID, NUMERICAL_IDENTIFIER, requestRules);


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### M-02 — Raising `minimumDisputeWindow` Above a Registered Liveness Range Permanently Blocks a Request
>
> - Severity: Medium
> - Status: Open
>
> `OOReporter.registerRequest` stores immutable liveness bounds that are validated against Managed OO configuration only at registration time. If `minimumDisputeWindow` later rises above the stored `maximumLiveness`, no value can satisfy both the reporter's registered range and Managed OO's current minimum. This can permanently block initialization and manual recovery for the affected request.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-96](https://linear.app/uma/issue/FRO-96/oz-retainer-07m-02-raising-minimumdisputewindow-above-a-registered) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Enforce the registered `minimumLiveness` as the reporter's runtime floor.
- Retain `maximumLiveness` unchanged in storage, return values, and events as an offchain initialization target rather than an onchain ceiling.
- Continue calling `setCustomLiveness`, so Managed OO enforces its current `minimumDisputeWindow` and technical maximum.
- Allow manual recovery above a stale registered maximum after an automatic re-request fails because it reused the previous liveness.
- Preserve registration validation, public ABI shapes, events, and custom-error signatures.

This is the runtime remediation specified in [FRO-107](https://linear.app/uma/issue/FRO-107/oz-retainer-07feature-do-not-cap-initialized-liveness-at-the). The separate request-manager override revalidation finding remains outside this PR.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 41 tests passed
- `git diff --check`