### PR TITLE
test[oz-retainer-07-m-01]: cover overlapping liveness targets

### DIFF
--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -245,6 +245,29 @@ contract OOReporterTest {
         reporter.registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules, MINIMUM_LIVENESS, belowOracleMinimum);
     }
 
+    function test_initializeRequestAcceptsLivenessWithinPartiallyOverlappingRange() external {
+        bytes memory requestRules = _requestRules("primary");
+        uint64 oracleMinimumLiveness = uint64(optimisticOracle.minimumDisputeWindow());
+        uint64 oracleMaximumLiveness = uint64(reporter.MAXIMUM_CUSTOM_LIVENESS());
+
+        vm.prank(requester);
+        reporter.registerRequest(
+            REQUEST_ID, BINARY_IDENTIFIER, requestRules, oracleMinimumLiveness - 1, oracleMaximumLiveness
+        );
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, 0, oracleMinimumLiveness);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        assertEq(request.liveness, oracleMinimumLiveness, "selected liveness mismatch");
+
+        bytes32 requestKey =
+            optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
+        assertEq(
+            optimisticOracle.getMockRequest(requestKey).customLiveness, oracleMinimumLiveness, "OO liveness mismatch"
+        );
+    }
+
     function test_initializeRequestSeedsDefaultBudgetAndCreatesManagedOORequest() external {
         bytes memory requestRules = _requestRules("numerical");
         _registerRequest(REQUEST_ID, NUMERICAL_IDENTIFIER, requestRules);


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### M-01 — Incorrect Liveness Range Validation in `OOReporter`
>
> - Severity: Medium
> - Status: Open
>
> `registerRequest` accepts ranges that overlap the current Managed OO bounds, so a caller selecting an endpoint outside those bounds cannot initialize the request.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-97](https://linear.app/uma/issue/FRO-97/oz-retainer-07m-01-incorrect-liveness-range-validation-in-ooreporter) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

This PR is stacked on #53, which makes `minimumLiveness` the hard onchain floor and `maximumLiveness` an offchain target rather than a runtime ceiling.

- Preserve the registration overlap predicate so the target range has a valid normal-path choice under the current Managed OO configuration.
- Continue relying on Managed OO to enforce its current minimum and exclusive technical maximum at initialization.
- Cover initialization inside the intersection of a partially overlapping target range and the current Managed OO bounds.
- Retain #53's coverage for initialization and manual recovery above a stale target maximum after configuration drift.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 42 tests passed
- `git diff --check`
