### PR TITLE
docs[oz-retainer-07-n-01]: document unbounded oracle allowance

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -96,6 +96,18 @@ If no trusted resolver settles the active request, `isRequestResolved(requestId)
 `getRequestResolution(requestId)` reverts. Downstream integrations should monitor this resolver dependency and keep any
 timeout or administrative recovery path in the market-side module that translates raw UMA outcomes and finalizes markets.
 
+## Oracle Reward Allowance
+
+The reporter pays request rewards from its own reward-currency balance. When its Managed OO allowance is below a
+request's reward, `_requestPrice` tops the allowance up to `type(uint256).max` instead of approving per request. This
+unbounded approval is intentional: it saves an approval on every subsequent request and re-request, and Managed OO only
+pulls each request's committed reward.
+
+The standing allowance keeps the oracle authorized over the reporter's entire reward balance, which is accepted under
+the reporter's trust model: the Managed OO address is fixed at initialization (the reporter has no oracle setter), and
+it is UMA-governed infrastructure in the same trust domain as this UMA-owned reporter. To bound the impact of an oracle
+compromise, operators should fund the reporter with a working reward float rather than a treasury balance.
+
 ## Rules Updates
 
 Only the requester that registered a `requestId` can update rules for that request. The reporter does not store update

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -522,6 +522,9 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             uint256 balance = currency.balanceOf(address(this));
             if (balance < reward) revert InsufficientRewardBalance(address(currency), balance, reward);
             if (currency.allowance(address(this), address(oracle)) < reward) {
+                // Unbounded approval is intentional: it saves an approval on every subsequent request, and the
+                // Managed OO is fixed at initialization within the same UMA-governed trust domain as this reporter.
+                // Exposure is capped by this contract's reward balance, which should hold only a working float.
                 currency.forceApprove(address(oracle), type(uint256).max);
             }
         }

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -286,6 +286,8 @@ interface IOOReporter {
     function updateRequestRules(bytes32 requestId, bytes calldata updatedRules) external;
 
     /// @notice Creates the Managed OO request for a registered request.
+    /// @dev Pays the reward from the reporter's reward-currency balance and, when the Managed OO allowance is below
+    /// the reward, tops it up to an unbounded approval for the trusted oracle instead of approving per request.
     /// @param requestId Registered request ID.
     /// @param reward Reward offered to a successful OO proposer.
     /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective
@@ -295,6 +297,8 @@ interface IOOReporter {
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
 
     /// @notice Allows an enabled oracle initializer to create a replacement Managed OO request after a callback opens the gate.
+    /// @dev Pays the reward from the reporter's reward-currency balance and, when the Managed OO allowance is below
+    /// the reward, tops it up to an unbounded approval for the trusted oracle instead of approving per request.
     /// @param requestId Registered request ID.
     /// @param reward Reward amount for the replacement request.
     /// @param proposalBond Bond requested from OO proposers/disputers, or zero to use the OO default. The effective


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### N-01 — Avoid Unbounded Allowance To The Oracle To Limit Exposure
>
> - Severity: Notes
> - Status: Open
>
> When allowance is below a request's reward, `_requestPrice` grants the oracle `type(uint256).max` approval instead of approving only the required reward. The trusted oracle retains standing authority over the reporter's entire reward-token balance; if compromised through a leaked key or malicious implementation, it could drain the full balance rather than only the amount committed to one request. Approve only the reward for each request so the allowance is consumed by `requestPrice`. If unlimited approval is retained for gas savings, document the decision and oracle trust assumptions.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-102](https://linear.app/uma/issue/FRO-102/oz-retainer-07n-01-avoid-unbounded-allowance-to-the-oracle-to-limit) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Retain the unbounded approval for gas savings and take the finding's documentation path: document the decision and the oracle trust assumptions instead of switching to per-request approvals.
- Document at the `_requestPrice` approval site that the unbounded allowance is intentional, that the Managed OO is fixed at initialization within the reporter's UMA-governed trust domain, and that exposure is capped by the reporter's reward balance.
- Add an "Oracle Reward Allowance" README section covering the decision, the trust assumptions, and the operational guidance to fund the reporter with a working reward float rather than a treasury balance.
- Document in `initializeRequest`/`rerequest` NatSpec that rewards are paid from the reporter's balance and that the reporter tops the trusted oracle's allowance up to an unbounded approval instead of approving per request.
- Documentation-only change: no behavior, selector, event/error signature, or storage changes.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 39 tests passed
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)