### PR TITLE
feat[oz-retainer-07]: add reversible pre-proposal pause and reward recovery

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ ast = true
 build_info = true
 extra_output = ["storageLayout"]
 optimizer = true
-optimizer_runs = 25
+optimizer_runs = 1
 via_ir = true
 
 # Fork testing configuration

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -84,6 +84,40 @@ Lifecycle events that refer to a specific Managed OO request consistently lead w
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,
 re-request-gate, rules-update, and resolution logs easy to correlate after a request has been replaced.
 
+## Reward Updates And Pre-Proposal Pauses
+
+Any enabled oracle initializer can call `setRequestReward(requestId, newReward)` while the active Managed OO request is
+still waiting for a proposal. The caller does not need to be the initializer that created the active request. Increasing
+the reward pulls only the delta from the reporter's reward balance; decreasing it, including setting it to zero, refunds
+the delta to the reporter or credits a deferred payout if the token transfer fails. The reporter updates its cached
+reward only after Managed OO accepts the change, so later automatic re-requests reuse the updated amount.
+
+Because enabled initializers can spend the reporter's reward balance, initializer infrastructure should enforce an
+operational maximum reward and the reporter should hold only the working balance needed for requests rather than a
+treasury balance.
+
+The Managed OO request manager can also update an active reward directly. An increase is funded by the request-manager
+caller rather than pulled from the reporter, while a decrease is always refunded or deferred to the original requester
+(the reporter). This prevents the request manager from using the reporter's token allowance to pull arbitrary funds. If
+a direct manager update is followed by a dispute, the reporter synchronizes its cached reward from the refund callback
+before attempting an automatic re-request.
+
+Setting a reward to zero does not cancel the request or stop proposals. To pause an abandoned or malformed request before
+proposal, the request manager must set its effective proposer whitelist to a real, enabled `AddressWhitelist` with no
+members. The reward can then be set to zero to recover its escrow. These calls can be batched through Managed OO
+multicall, with the whitelist change first to reduce the proposal race window; no separate cancellation state is
+created.
+
+To restore a paused request, an oracle initializer first restores the reward through `setRequestReward` while the empty
+whitelist still blocks proposals. The request manager then restores the prior whitelist or sets the custom whitelist to
+`address(0)` to return to the default. A `DisabledAddressWhitelist` is permissionless and therefore does not pause a
+request, while `address(0)` restores the default whitelist rather than disabling proposals. If the earlier refund was
+deferred, the owner must claim it before that balance can fund restoration.
+
+Reward changes are valid only before a proposal. A proposer can still win transaction ordering if its proposal lands
+before the pause transaction. Custom proposer whitelists are keyed without the request timestamp and therefore persist
+across re-requests for the same requester, identifier, and request rules until explicitly restored.
+
 ## Trusted Resolver Dependency
 
 `OOReporter` stores final outcomes only after Managed OO settles the active request and calls `priceSettled(...)` with a

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -84,6 +84,16 @@ Lifecycle events that refer to a specific Managed OO request consistently lead w
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,
 re-request-gate, rules-update, and resolution logs easy to correlate after a request has been replaced.
 
+## Bond And Liveness Events
+
+`BondUpdated` and `CustomLivenessUpdated` expose requester-controlled changes to the concrete Managed OO request. Each
+request starts with a bond equal to its `finalFee` and custom liveness equal to `0`, so the first update event for each
+setting reports that default as its old value.
+
+To reconstruct the effective bond and liveness at proposal time, consumers must combine those events with
+`CustomBondSet` and `CustomLivenessSet`. These request-manager overrides take precedence when `proposePriceFor(...)`
+applies the proposal settings, even if the requester changed the concrete request afterward.
+
 ## Reward Updates And Pre-Proposal Pauses
 
 Any enabled oracle initializer can call `setRequestReward(requestId, newReward)` while the active Managed OO request is

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -98,9 +98,10 @@ treasury balance.
 
 The Managed OO request manager can also update an active reward directly. An increase is funded by the request-manager
 caller rather than pulled from the reporter, while a decrease is always refunded or deferred to the original requester
-(the reporter). This prevents the request manager from using the reporter's token allowance to pull arbitrary funds. If
-a direct manager update is followed by a dispute, the reporter synchronizes its cached reward from the refund callback
-before attempting an automatic re-request.
+(the reporter). This prevents the request manager from using the reporter's token allowance to pull arbitrary funds.
+Managed OO is authoritative after a direct manager update: `getRequest(requestId).reward` can retain its previous value
+until `setRequestReward` reads the live oracle reward or a dispute callback synchronizes the refunded reward. The dispute
+path updates the cache before attempting an automatic re-request.
 
 Setting a reward to zero does not cancel the request or stop proposals. To pause an abandoned or malformed request before
 proposal, the request manager must set its effective proposer whitelist to a real, enabled `AddressWhitelist` with no

--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -100,7 +100,8 @@ Any enabled oracle initializer can call `setRequestReward(requestId, newReward)`
 still waiting for a proposal. The caller does not need to be the initializer that created the active request. Increasing
 the reward pulls only the delta from the reporter's reward balance; decreasing it, including setting it to zero, refunds
 the delta to the reporter or credits a deferred payout if the token transfer fails. The reporter updates its cached
-reward only after Managed OO accepts the change, so later automatic re-requests reuse the updated amount.
+reward before calling Managed OO so callbacks observe the new amount. If the oracle rejects the change, the transaction
+reverts the cache update as well; successful changes are reused by later automatic re-requests.
 
 Because enabled initializers can spend the reporter's reward balance, initializer infrastructure should enforce an
 operational maximum reward and the reporter should hold only the working balance needed for requests rather than a

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -255,28 +255,15 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         IERC20 currency = rewardCurrency();
         IOptimisticOracleV2 oracle = optimisticOracle();
-        bytes memory callData = abi.encodeCall(
-            IOptimisticOracleV2.getRequest,
-            (address(this), request.priceIdentifier, request.requestTimestamp, request.requestRules)
+        uint256 oldReward = oracle.getRequestReward(
+            address(this), request.priceIdentifier, request.requestTimestamp, request.requestRules
         );
-        uint256 oldReward;
-        // Decode only Request.reward (word 14, requiring 15 words / 0x1e0 bytes) to stay below EIP-170.
-        assembly {
-            let result := mload(0x40)
-            mstore(0x40, add(result, 0x220))
-            if iszero(staticcall(gas(), oracle, add(callData, 0x20), mload(callData), result, 0x220)) {
-                returndatacopy(result, 0, returndatasize())
-                revert(result, returndatasize())
-            }
-            if lt(returndatasize(), 0x1e0) { revert(0, 0) }
-            oldReward := mload(add(result, 0x1c0))
-        }
         if (newReward > oldReward) {
             _prepareReward(currency, oracle, newReward - oldReward);
         }
 
-        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
         request.reward = newReward;
+        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
 
         emit RequestRewardUpdated(
             requestId, request.requestTimestamp, msg.sender, address(currency), oldReward, newReward

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -248,6 +248,42 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     /// @inheritdoc IOOReporter
+    function setRequestReward(bytes32 requestId, uint256 newReward) external onlyOracleInitializer {
+        RequestData storage request = _requireRegistered(requestId);
+        if (!request.initialized) revert RequestNotInitialized();
+        if (request.resolved) revert RequestAlreadyResolved();
+
+        IERC20 currency = rewardCurrency();
+        IOptimisticOracleV2 oracle = optimisticOracle();
+        bytes memory callData = abi.encodeCall(
+            IOptimisticOracleV2.getRequest,
+            (address(this), request.priceIdentifier, request.requestTimestamp, request.requestRules)
+        );
+        uint256 oldReward;
+        // Decode only Request.reward (word 14, requiring 15 words / 0x1e0 bytes) to stay below EIP-170.
+        assembly {
+            let result := mload(0x40)
+            mstore(0x40, add(result, 0x220))
+            if iszero(staticcall(gas(), oracle, add(callData, 0x20), mload(callData), result, 0x220)) {
+                returndatacopy(result, 0, returndatasize())
+                revert(result, returndatasize())
+            }
+            if lt(returndatasize(), 0x1e0) { revert(0, 0) }
+            oldReward := mload(add(result, 0x1c0))
+        }
+        if (newReward > oldReward) {
+            _prepareReward(currency, oracle, newReward - oldReward);
+        }
+
+        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
+        request.reward = newReward;
+
+        emit RequestRewardUpdated(
+            requestId, request.requestTimestamp, msg.sender, address(currency), oldReward, newReward
+        );
+    }
+
+    /// @inheritdoc IOOReporter
     function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness)
         external
         onlyOracleInitializer
@@ -322,7 +358,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
     /// @notice Managed OO dispute callback. Attempts one auto re-request, otherwise opens the manual gate.
     /// @inheritdoc IOptimisticRequester
-    function priceDisputed(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256)
+    function priceDisputed(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256 refund)
         external
         override
         onlyOptimisticOracle
@@ -330,6 +366,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         (bytes32 requestId, RequestData storage request, bool shouldIgnore) =
             _loadCallbackRequest(identifier, timestamp, requestRules);
         if (shouldIgnore || request.resolved) return;
+
+        request.reward = refund;
 
         if (!request.automaticDisputeRerequestUsed && _shouldAttemptAutomaticRerequest(request)) {
             try this.executeAutomaticRerequest(requestId, RerequestType.AutomaticDispute) {
@@ -519,11 +557,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         IERC20 currency = rewardCurrency();
         IOptimisticOracleV2 oracle = optimisticOracle();
         if (reward > 0) {
-            uint256 balance = currency.balanceOf(address(this));
-            if (balance < reward) revert InsufficientRewardBalance(address(currency), balance, reward);
-            if (currency.allowance(address(this), address(oracle)) < reward) {
-                currency.forceApprove(address(oracle), type(uint256).max);
-            }
+            _prepareReward(currency, oracle, reward);
         }
 
         oracle.requestPrice(priceIdentifier, requestTimestamp, requestRules, currency, reward);
@@ -534,6 +568,15 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         }
 
         oracle.setCustomLiveness(priceIdentifier, requestTimestamp, requestRules, liveness);
+    }
+
+    /// @dev Verifies reporter funding and grants the oracle a reusable allowance for a reward pull.
+    function _prepareReward(IERC20 currency, IOptimisticOracleV2 oracle, uint256 amount) private {
+        uint256 balance = currency.balanceOf(address(this));
+        if (balance < amount) revert InsufficientRewardBalance(address(currency), balance, amount);
+        if (currency.allowance(address(this), address(oracle)) < amount) {
+            currency.forceApprove(address(oracle), type(uint256).max);
+        }
     }
 
     /// @dev Keeps the reporter off Managed OO's default liveness path and within the registered bounds.

--- a/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOOReporter.sol
@@ -169,6 +169,15 @@ interface IOOReporter {
     event RequestRulesUpdated(
         bytes32 indexed requestId, uint256 indexed timestamp, address indexed updater, bytes updatedRules
     );
+    /// @notice Emitted when an approved oracle initializer updates the active Managed OO request reward.
+    event RequestRewardUpdated(
+        bytes32 indexed requestId,
+        uint256 indexed requestTimestamp,
+        address indexed updater,
+        address rewardCurrency,
+        uint256 oldReward,
+        uint256 newReward
+    );
     /// @notice Emitted when a final raw UMA outcome is stored for a request.
     event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
     /// @notice Emitted when a callback opens the oracle-initializer re-request path.
@@ -284,6 +293,13 @@ interface IOOReporter {
     /// @param requestId Registered request ID.
     /// @param updatedRules Updated prediction market request rules.
     function updateRequestRules(bytes32 requestId, bytes calldata updatedRules) external;
+
+    /// @notice Updates the reward on an initialized, unresolved Managed OO request before a proposal is made.
+    /// @dev Uses the reward currently stored by Managed OO as the source of truth. Reward increases are funded from
+    /// this reporter's configured reward-currency balance.
+    /// @param requestId Registered request ID.
+    /// @param newReward New reward amount for the active Managed OO request.
+    function setRequestReward(bytes32 requestId, uint256 newReward) external;
 
     /// @notice Creates the Managed OO request for a registered request.
     /// @param requestId Registered request ID.

--- a/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
@@ -123,6 +123,17 @@ interface IOptimisticOracleV2 {
     /// @param updatedRules Updated request rules to record for the request.
     function updateRequestRules(bytes32 identifier, bytes memory requestRules, bytes memory updatedRules) external;
 
+    /// @notice Gets the current reward for an OO request tuple.
+    /// @param requester Sender of the initial price request.
+    /// @param identifier Price identifier to identify the existing request.
+    /// @param timestamp Timestamp to identify the existing request.
+    /// @param requestRules Request rules of the price being requested.
+    /// @return reward Current reward amount.
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        view
+        returns (uint256 reward);
+
     /// @notice Gets current request data for an OO request tuple.
     /// @param requester Sender of the initial price request.
     /// @param identifier Price identifier to identify the existing request.

--- a/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
@@ -66,6 +66,13 @@ interface IOptimisticOracleV2 {
         uint256 reward
     ) external returns (uint256 totalBond);
 
+    /// @notice Updates the reward associated with a price request before a proposal is made.
+    /// @param identifier Price identifier to identify the existing request.
+    /// @param timestamp Timestamp to identify the existing request.
+    /// @param requestRules Request rules of the price being requested.
+    /// @param newReward New reward amount. Any increase will be pulled from the caller.
+    function setReward(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256 newReward) external;
+
     /// @notice Set the proposal bond associated with a price request.
     /// @param identifier Price identifier to identify the existing request.
     /// @param timestamp Timestamp to identify the existing request.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -63,6 +63,14 @@ contract OOReporterTest {
     event RequestRulesUpdated(
         bytes32 indexed requestId, uint256 indexed timestamp, address indexed updater, bytes updatedRules
     );
+    event RequestRewardUpdated(
+        bytes32 indexed requestId,
+        uint256 indexed requestTimestamp,
+        address indexed updater,
+        address rewardCurrency,
+        uint256 oldReward,
+        uint256 newReward
+    );
     event RequestResolved(bytes32 indexed requestId, uint256 indexed requestTimestamp, int256 outcome);
     event RequestRerequestAllowed(
         bytes32 indexed requestId, uint256 indexed requestTimestamp, RerequestTrigger indexed trigger
@@ -345,6 +353,152 @@ contract OOReporterTest {
         reporter.initializeRequest(REQUEST_ID, 0, 0, STRICT_MINIMUM_LIVENESS);
     }
 
+    function test_setRequestRewardRejectsUnauthorizedAndInvalidLifecycle() external {
+        bytes memory requestRules = _requestRules("primary");
+
+        vm.prank(unauthorized);
+        vm.expectRevert(IOOReporter.CallerNotOracleInitializer.selector);
+        reporter.setRequestReward(REQUEST_ID, 0);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(IOOReporter.RequestNotRegistered.selector);
+        reporter.setRequestReward(REQUEST_ID, 0);
+
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(IOOReporter.RequestNotInitialized.selector);
+        reporter.setRequestReward(REQUEST_ID, 0);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        optimisticOracle.settle(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, 1 ether);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(IOOReporter.RequestAlreadyResolved.selector);
+        reporter.setRequestReward(REQUEST_ID, 0);
+    }
+
+    function test_setRequestRewardUpdatesOracleCacheFundingAllowanceAndEvent() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+        usdc.mint(address(reporter), REREQUEST_REWARD);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        bytes32 requestKey =
+            optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        vm.prank(address(reporter));
+        usdc.approve(address(optimisticOracle), 0);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRewardUpdated(
+            REQUEST_ID, request.requestTimestamp, oracleInitializer, address(usdc), REWARD, REREQUEST_REWARD
+        );
+        vm.prank(oracleInitializer);
+        reporter.setRequestReward(REQUEST_ID, REREQUEST_REWARD);
+
+        RequestData memory increased = reporter.getRequest(REQUEST_ID);
+        assertEq(increased.reward, REREQUEST_REWARD, "cached increased reward mismatch");
+        assertEq(
+            optimisticOracle.getMockRequest(requestKey).reward, REREQUEST_REWARD, "oracle increased reward mismatch"
+        );
+        assertEq(increased.oracleInitializer, oracleInitializer, "stored initializer should not change");
+        assertEq(usdc.balanceOf(address(reporter)), 0, "increase should pull only the delta");
+        assertEq(usdc.balanceOf(address(optimisticOracle)), REREQUEST_REWARD, "oracle increase balance mismatch");
+        assertEq(
+            usdc.allowance(address(reporter), address(optimisticOracle)),
+            type(uint256).max,
+            "increase should restore max allowance"
+        );
+
+        vm.prank(oracleInitializer);
+        reporter.setRequestReward(REQUEST_ID, REWARD);
+
+        assertEq(reporter.getRequest(REQUEST_ID).reward, REWARD, "cached decreased reward mismatch");
+        assertEq(optimisticOracle.getMockRequest(requestKey).reward, REWARD, "oracle decreased reward mismatch");
+        assertEq(usdc.balanceOf(address(reporter)), REREQUEST_REWARD - REWARD, "decrease refund mismatch");
+
+        vm.prank(oracleInitializer);
+        reporter.setRequestReward(REQUEST_ID, 0);
+
+        assertEq(reporter.getRequest(REQUEST_ID).reward, 0, "cached zero reward mismatch");
+        assertEq(optimisticOracle.getMockRequest(requestKey).reward, 0, "oracle zero reward mismatch");
+        assertEq(usdc.balanceOf(address(reporter)), REREQUEST_REWARD, "zero reward refund mismatch");
+        assertEq(usdc.balanceOf(address(optimisticOracle)), 0, "oracle should hold no reward");
+    }
+
+    function test_setRequestRewardRejectsInsufficientDeltaBalance() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+        usdc.mint(address(reporter), REWARD);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOOReporter.InsufficientRewardBalance.selector, address(usdc), 0, REREQUEST_REWARD - REWARD
+            )
+        );
+        reporter.setRequestReward(REQUEST_ID, REREQUEST_REWARD);
+
+        assertEq(reporter.getRequest(REQUEST_ID).reward, REWARD, "failed update should preserve cached reward");
+    }
+
+    function test_setRequestRewardUsesOracleRewardWhenCacheIsStale() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+        usdc.mint(address(reporter), REWARD);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        uint256 managedReward = REWARD / 2;
+        optimisticOracle.setRewardFor(
+            address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, managedReward
+        );
+        usdc.mint(address(reporter), REREQUEST_REWARD - REWARD);
+
+        vm.prank(address(reporter));
+        usdc.approve(address(optimisticOracle), 0);
+
+        vm.expectEmit(address(reporter));
+        emit RequestRewardUpdated(
+            REQUEST_ID, request.requestTimestamp, oracleInitializer, address(usdc), managedReward, REREQUEST_REWARD
+        );
+        vm.prank(oracleInitializer);
+        reporter.setRequestReward(REQUEST_ID, REREQUEST_REWARD);
+
+        assertEq(reporter.getRequest(REQUEST_ID).reward, REREQUEST_REWARD, "cache should resync to new reward");
+        assertEq(usdc.balanceOf(address(reporter)), 0, "increase should use oracle reward as delta baseline");
+    }
+
+    function test_setRequestRewardRevertsAfterProposalWithoutChangingCache() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, 0, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        optimisticOracle.markProposed(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+        usdc.mint(address(reporter), REWARD);
+
+        vm.prank(oracleInitializer);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "already proposed"));
+        reporter.setRequestReward(REQUEST_ID, REWARD);
+
+        assertEq(reporter.getRequest(REQUEST_ID).reward, 0, "failed update should preserve cached reward");
+    }
+
     function test_updateRequestRulesForwardsToOptimisticOracle() external {
         bytes memory requestRules = _requestRules("primary");
         bytes memory firstUpdatedRules = bytes("first rules update");
@@ -482,6 +636,40 @@ contract OOReporterTest {
         assertTrue(afterAuto.automaticDisputeRerequestUsed, "automatic dispute re-request should be marked used");
         assertEq(afterAuto.requestTimestamp, block.timestamp, "automatic dispute should advance timestamp");
         assertEq(afterAuto.manualRerequestsRemaining, DEFAULT_REREQUEST_BUDGET, "dispute should not consume budget");
+    }
+
+    function test_priceDisputedRerequestsWithEffectiveOracleRewardAfterManagerChange() external {
+        bytes memory requestRules = _requestRules("primary");
+        _registerRequest(REQUEST_ID, BINARY_IDENTIFIER, requestRules);
+        usdc.mint(address(reporter), REWARD);
+
+        vm.prank(oracleInitializer);
+        reporter.initializeRequest(REQUEST_ID, REWARD, PROPOSAL_BOND, LIVENESS);
+
+        RequestData memory request = reporter.getRequest(REQUEST_ID);
+        uint256 managedReward = REWARD / 2;
+        optimisticOracle.setRewardFor(
+            address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules, managedReward
+        );
+        assertEq(reporter.getRequest(REQUEST_ID).reward, REWARD, "manager change should leave reporter cache stale");
+
+        vm.warp(block.timestamp + 1);
+        optimisticOracle.disputePrice(address(reporter), BINARY_IDENTIFIER, request.requestTimestamp, requestRules);
+
+        RequestData memory rerequested = reporter.getRequest(REQUEST_ID);
+        bytes32 replacementKey =
+            optimisticOracle.requestKey(address(reporter), BINARY_IDENTIFIER, block.timestamp, requestRules);
+        assertEq(rerequested.reward, managedReward, "dispute refund should refresh cached reward");
+        assertEq(
+            optimisticOracle.getMockRequest(replacementKey).reward,
+            managedReward,
+            "automatic re-request should use effective reward"
+        );
+        assertEq(
+            usdc.balanceOf(address(reporter)),
+            REWARD - managedReward,
+            "automatic re-request should leave prior manager refund"
+        );
     }
 
     function test_executeAutomaticRerequestRejectsNonSelfCaller() external {

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -395,6 +395,7 @@ contract OOReporterTest {
 
         vm.prank(address(reporter));
         usdc.approve(address(optimisticOracle), 0);
+        optimisticOracle.expectReporterRewardDuringSetReward(REQUEST_ID, REREQUEST_REWARD);
 
         vm.expectEmit(address(reporter));
         emit RequestRewardUpdated(

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -14,6 +14,7 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         bool callbackOnPriceDisputed;
         bool callbackOnPriceSettled;
         bool settled;
+        bool proposed;
         IERC20 currency;
         uint256 reward;
         uint256 bond;
@@ -96,6 +97,28 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         }
 
         return request.bond;
+    }
+
+    function setReward(bytes32 identifier, uint256 timestamp, bytes memory requestRules, uint256 newReward) external {
+        _setReward(requests[requestKey(msg.sender, identifier, timestamp, requestRules)], msg.sender, newReward);
+    }
+
+    function setRewardFor(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory requestRules,
+        uint256 newReward
+    ) external {
+        _setReward(requests[requestKey(requester, identifier, timestamp, requestRules)], requester, newReward);
+    }
+
+    function markProposed(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+    {
+        MockRequest storage request = requests[requestKey(requester, identifier, timestamp, requestRules)];
+        require(request.requested, "not requested");
+        request.proposed = true;
     }
 
     function setEventBased(bytes32 identifier, uint256 timestamp, bytes memory requestRules) external {
@@ -204,5 +227,22 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
 
     function setMinimumDisputeWindow(uint256 newMinimumDisputeWindow) external {
         minimumDisputeWindow = newMinimumDisputeWindow;
+    }
+
+    function _setReward(MockRequest storage request, address requester, uint256 newReward) private {
+        require(request.requested, "not requested");
+        require(!request.proposed, "already proposed");
+
+        uint256 oldReward = request.reward;
+        request.reward = newReward;
+
+        if (newReward > oldReward) {
+            require(
+                request.currency.transferFrom(msg.sender, address(this), newReward - oldReward),
+                "reward transfer failed"
+            );
+        } else if (oldReward > newReward) {
+            require(request.currency.transfer(requester, oldReward - newReward), "refund transfer failed");
+        }
     }
 }

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -5,6 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {IOptimisticOracleV2} from "src/interfaces/IOptimisticOracleV2.sol";
 import {IOptimisticRequester} from "src/interfaces/IOptimisticRequester.sol";
+import {IOOReporter} from "src/interfaces/IOOReporter.sol";
 
 contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     struct MockRequest {
@@ -32,6 +33,8 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     mapping(IERC20 currency => mapping(address deferredRecipient => uint256 amount)) public deferredPayouts;
     uint256 public minimumDisputeWindow = 5 minutes;
     bool public deferNextDisputeRefund;
+    bytes32 private expectedRewardRequestId;
+    uint256 private expectedReporterReward;
 
     function getMockRequest(bytes32 key) external view returns (MockRequest memory) {
         return requests[key];
@@ -67,6 +70,14 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
             finalFee: 0,
             proposalTime: 0
         });
+    }
+
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        view
+        returns (uint256 reward)
+    {
+        return requests[requestKey(requester, identifier, timestamp, requestRules)].reward;
     }
 
     function requestKey(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
@@ -229,9 +240,22 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         minimumDisputeWindow = newMinimumDisputeWindow;
     }
 
+    function expectReporterRewardDuringSetReward(bytes32 requestId, uint256 reward) external {
+        expectedRewardRequestId = requestId;
+        expectedReporterReward = reward;
+    }
+
     function _setReward(MockRequest storage request, address requester, uint256 newReward) private {
         require(request.requested, "not requested");
         require(!request.proposed, "already proposed");
+
+        if (expectedRewardRequestId != bytes32(0)) {
+            require(
+                IOOReporter(requester).getRequest(expectedRewardRequestId).reward == expectedReporterReward,
+                "reporter reward not updated"
+            );
+            expectedRewardRequestId = bytes32(0);
+        }
 
         uint256 oldReward = request.reward;
         request.reward = newReward;

--- a/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol
@@ -277,6 +277,26 @@ contract ManagedOptimisticOracleV2 is ManagedOptimisticOracleV2Interface, Optimi
     }
 
     /**
+     * @notice Updates the reward for a concrete price request.
+     * @dev Only callable by a request manager while the request is in State.Requested. Increases are funded by the
+     * caller, while decreases are always refunded to the original requester.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the concrete request round.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param newReward new reward amount, which can be zero.
+     */
+    function requestManagerSetReward(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        uint256 newReward
+    ) external override onlyRequestManager {
+        _setReward(requester, identifier, timestamp, ancillaryData, newReward);
+    }
+
+    /**
      * @notice Set the proposal bond associated with a price request.
      * @dev Can be called before the request exists (pre-configuration) or after. Settings are applied when
      * proposePriceFor() is called. This would also override any subsequent calls to setBond() by the requester.

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -237,14 +237,27 @@ contract OptimisticOracleV2 is
         nonReentrant
         returns (uint256 totalBond)
     {
-        require(
-            _getState(msg.sender, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
-        Request storage request = _getRequest(msg.sender, identifier, timestamp, ancillaryData);
+        Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         request.requestSettings.bond = bond;
 
         // Total bond is the final fee + the newly set bond.
         return bond + request.finalFee;
+    }
+
+    /**
+     * @notice Updates the reward associated with a price request.
+     * @dev Only callable while the request is in State.Requested (before any proposal). Increases are pulled from the
+     * caller, while decreases are refunded to the requester and may be deferred if the transfer fails.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param newReward new reward amount, which can be zero.
+     */
+    function setReward(bytes32 identifier, uint256 timestamp, bytes memory ancillaryData, uint256 newReward)
+        external
+        override
+    {
+        _setReward(msg.sender, identifier, timestamp, ancillaryData, newReward);
     }
 
     /**
@@ -262,10 +275,7 @@ contract OptimisticOracleV2 is
         override
         nonReentrant
     {
-        require(
-            _getState(msg.sender, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
-        _getRequest(msg.sender, identifier, timestamp, ancillaryData).requestSettings.refundOnDispute = true;
+        _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData).requestSettings.refundOnDispute = true;
     }
 
     /**
@@ -284,11 +294,9 @@ contract OptimisticOracleV2 is
         bytes memory ancillaryData,
         uint256 customLiveness
     ) external override nonReentrant {
-        require(
-            _getState(msg.sender, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
+        Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         _validateLiveness(customLiveness);
-        _getRequest(msg.sender, identifier, timestamp, ancillaryData).requestSettings.customLiveness = customLiveness;
+        request.requestSettings.customLiveness = customLiveness;
     }
 
     /**
@@ -316,10 +324,7 @@ contract OptimisticOracleV2 is
         override
         nonReentrant
     {
-        require(
-            _getState(msg.sender, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
-        Request storage request = _getRequest(msg.sender, identifier, timestamp, ancillaryData);
+        Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         request.requestSettings.eventBased = true;
         request.requestSettings.refundOnDispute = true;
     }
@@ -343,10 +348,7 @@ contract OptimisticOracleV2 is
         bool callbackOnPriceDisputed,
         bool callbackOnPriceSettled
     ) external override nonReentrant {
-        require(
-            _getState(msg.sender, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
-        Request storage request = _getRequest(msg.sender, identifier, timestamp, ancillaryData);
+        Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         request.requestSettings.callbackOnPriceProposed = callbackOnPriceProposed;
         request.requestSettings.callbackOnPriceDisputed = callbackOnPriceDisputed;
         request.requestSettings.callbackOnPriceSettled = callbackOnPriceSettled;
@@ -375,10 +377,7 @@ contract OptimisticOracleV2 is
         int256 proposedPrice
     ) public virtual override nonReentrant returns (uint256 totalBond) {
         require(proposer != address(0), ProposerAddressCannotBeZero());
-        require(
-            _getState(requester, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
-        );
-        Request storage request = _getRequest(requester, identifier, timestamp, ancillaryData);
+        Request storage request = _getRequestedRequest(requester, identifier, timestamp, ancillaryData);
         if (request.requestSettings.eventBased) {
             require(proposedPrice != TOO_EARLY_RESPONSE, CannotProposeTooEarly());
         }
@@ -725,6 +724,45 @@ contract OptimisticOracleV2 is
             OptimisticRequester(requester).priceSettled(identifier, timestamp, ancillaryData, request.resolvedPrice);
         }
         _endReentrantGuardDisabled();
+    }
+
+    function _setReward(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        uint256 newReward
+    ) internal {
+        // Guard here so requester and request-manager entry points share one reentrancy boundary.
+        _preEntranceCheckAndSet();
+        Request storage request = _getRequestedRequest(requester, identifier, timestamp, ancillaryData);
+        uint256 oldReward = request.reward;
+        request.reward = newReward;
+
+        // Branch conditions guarantee the delta subtractions cannot underflow.
+        if (newReward > oldReward) {
+            unchecked {
+                request.currency.safeTransferFrom(msg.sender, address(this), newReward - oldReward);
+            }
+        } else if (newReward < oldReward) {
+            unchecked {
+                _transferOrDeferPayout(request.currency, requester, oldReward - newReward);
+            }
+        }
+
+        emit RewardUpdated(requester, identifier, timestamp, ancillaryData, msg.sender, oldReward, newReward);
+        _postEntranceReset();
+    }
+
+    function _getRequestedRequest(address requester, bytes32 identifier, uint256 timestamp, bytes memory ancillaryData)
+        private
+        view
+        returns (Request storage request)
+    {
+        require(
+            _getState(requester, identifier, timestamp, ancillaryData) == State.Requested, RequestStateNotRequested()
+        );
+        return _getRequest(requester, identifier, timestamp, ancillaryData);
     }
 
     // Attempts to transfer a payout for a recipient. If the payout fails, it accrues the payout amount to the recipient

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -238,7 +238,9 @@ contract OptimisticOracleV2 is
         returns (uint256 totalBond)
     {
         Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
+        uint256 oldBond = request.requestSettings.bond;
         request.requestSettings.bond = bond;
+        emit BondUpdated(msg.sender, identifier, timestamp, ancillaryData, oldBond, bond);
 
         // Total bond is the final fee + the newly set bond.
         return bond + request.finalFee;
@@ -296,7 +298,9 @@ contract OptimisticOracleV2 is
     ) external override nonReentrant {
         Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         _validateLiveness(customLiveness);
+        uint256 oldCustomLiveness = request.requestSettings.customLiveness;
         request.requestSettings.customLiveness = customLiveness;
+        emit CustomLivenessUpdated(msg.sender, identifier, timestamp, ancillaryData, oldCustomLiveness, customLiveness);
     }
 
     /**

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -246,8 +246,8 @@ contract OptimisticOracleV2 is
 
     /**
      * @notice Updates the reward associated with a price request.
-     * @dev Only callable while the request is in State.Requested (before any proposal). Increases are pulled from the
-     * caller, while decreases are refunded to the requester and may be deferred if the transfer fails.
+     * @dev Only callable while the request is in State.Requested (before any proposal). The caller is the requester:
+     * it funds increases and receives decreases, which may be deferred if the transfer fails.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -590,6 +590,17 @@ contract OptimisticOracleV2 is
         emit ClaimedDeferredPayout(address(currency), deferredRecipient, repaymentAddress, amount);
     }
 
+    /// @inheritdoc OptimisticOracleV2Interface
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory ancillaryData)
+        public
+        view
+        override
+        nonReentrantView
+        returns (uint256 reward)
+    {
+        return _getRequest(requester, identifier, timestamp, ancillaryData).reward;
+    }
+
     /**
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.

--- a/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
@@ -74,7 +74,9 @@ abstract contract ManagedOptimisticOracleV2Interface {
     /**
      * @notice Updates the reward for a concrete price request.
      * @dev Only callable by a request manager while the request is in the Requested state. Reward increases are
-     * funded by the caller, while decreases are always refunded to the original requester.
+     * funded by the caller, while decreases are always refunded to the original requester. Consequently, a request
+     * manager cannot recover an over-funded reward; only the original requester receives funds returned by a later
+     * decrease.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identify the concrete request round.

--- a/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
@@ -70,4 +70,22 @@ abstract contract ManagedOptimisticOracleV2Interface {
         bytes ancillaryData,
         bytes updatedRules
     );
+
+    /**
+     * @notice Updates the reward for a concrete price request.
+     * @dev Only callable by a request manager while the request is in the Requested state. Reward increases are
+     * funded by the caller, while decreases are always refunded to the original requester.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the concrete request round.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param newReward new reward amount, which can be zero.
+     */
+    function requestManagerSetReward(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        uint256 newReward
+    ) external virtual;
 }

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -62,6 +62,36 @@ abstract contract OptimisticOracleV2Interface {
         uint256 oldReward,
         uint256 newReward
     );
+    /// @notice Emitted when the proposal bond associated with a price request is updated.
+    /// @param requester sender of the initial price request.
+    /// @param identifier price identifier identifying the existing request.
+    /// @param timestamp timestamp identifying the existing request.
+    /// @param ancillaryData ancillary data of the price being requested.
+    /// @param oldBond previous custom bond amount.
+    /// @param newBond new custom bond amount.
+    event BondUpdated(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        uint256 oldBond,
+        uint256 newBond
+    );
+    /// @notice Emitted when the custom liveness associated with a price request is updated.
+    /// @param requester sender of the initial price request.
+    /// @param identifier price identifier identifying the existing request.
+    /// @param timestamp timestamp identifying the existing request.
+    /// @param ancillaryData ancillary data of the price being requested.
+    /// @param oldCustomLiveness previous custom liveness value.
+    /// @param newCustomLiveness new custom liveness value.
+    event CustomLivenessUpdated(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        uint256 oldCustomLiveness,
+        uint256 newCustomLiveness
+    );
     event ProposePrice(
         address indexed requester,
         address indexed proposer,

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -53,6 +53,15 @@ abstract contract OptimisticOracleV2Interface {
         uint256 reward,
         uint256 finalFee
     );
+    event RewardUpdated(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        address updater,
+        uint256 oldReward,
+        uint256 newReward
+    );
     event ProposePrice(
         address indexed requester,
         address indexed proposer,
@@ -171,6 +180,19 @@ abstract contract OptimisticOracleV2Interface {
         external
         virtual
         returns (uint256 totalBond);
+
+    /**
+     * @notice Updates the reward associated with a price request.
+     * @dev Only callable by the requester while the request is in the Requested state. Reward increases are pulled
+     * from the caller, while decreases are refunded to the requester and may be deferred if the transfer fails.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param newReward new reward amount, which can be zero.
+     */
+    function setReward(bytes32 identifier, uint256 timestamp, bytes memory ancillaryData, uint256 newReward)
+        external
+        virtual;
 
     /**
      * @notice Sets the request to refund the reward if the proposal is disputed. This can help to "hedge" the caller

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -183,8 +183,8 @@ abstract contract OptimisticOracleV2Interface {
 
     /**
      * @notice Updates the reward associated with a price request.
-     * @dev Only callable by the requester while the request is in the Requested state. Reward increases are pulled
-     * from the caller, while decreases are refunded to the requester and may be deferred if the transfer fails.
+     * @dev Only callable by the requester while the request is in the Requested state. The requester funds increases
+     * and receives decreases, which may be deferred if the transfer fails.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -394,6 +394,20 @@ abstract contract OptimisticOracleV2Interface {
     function claimDeferredPayout(IERC20 currency, address repaymentAddress) external virtual;
 
     /**
+     * @notice Gets the current reward for a price request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return reward current reward amount.
+     */
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory ancillaryData)
+        public
+        view
+        virtual
+        returns (uint256 reward);
+
+    /**
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.

--- a/test/DeferredPayout.t.sol
+++ b/test/DeferredPayout.t.sol
@@ -163,6 +163,20 @@ contract DeferredPayoutTest is Test {
         oo.disputePrice(requester, IDENTIFIER, timestamp, ANCILLARY_DATA);
     }
 
+    function testRewardDecreaseWithBlacklistedRequesterIsDeferred() public {
+        uint256 timestamp = _makeRequest(blacklistToken);
+        blacklistToken.setBlacklisted(requester, true);
+
+        vm.expectEmit(true, true, true, true);
+        emit OptimisticOracleV2Interface.PayoutDeferred(address(blacklistToken), requester, REWARD);
+        vm.prank(requester);
+        oo.setReward(IDENTIFIER, timestamp, ANCILLARY_DATA, 0);
+
+        assertEq(oo.getRequest(requester, IDENTIFIER, timestamp, ANCILLARY_DATA).reward, 0);
+        assertEq(oo.deferredPayouts(blacklistToken, requester), REWARD);
+        assertEq(blacklistToken.balanceOf(address(oo)), REWARD);
+    }
+
     // -------------------- Blacklist Token Tests (Returns false) --------------------
 
     function testExpiredSettlementWithBlacklistedProposer() public {

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -595,6 +595,108 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(req.requestSettings.bond, 5 ether);
     }
 
+    // -------------------- Reward Management --------------------
+
+    function testRequesterSetRewardUpdatesDeltaAndAllowsZero() external {
+        uint256 t = moo.getCurrentTime();
+        _makeRequest(requester, t, 10 ether);
+        currency.mint(requester, 10 ether);
+
+        vm.prank(nonRequester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setReward(IDENTIFIER, t, ANCILLARY, 1 ether);
+
+        uint256 requesterBalance = currency.balanceOf(requester);
+        uint256 oracleBalance = currency.balanceOf(address(moo));
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.RewardUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, requester, 10 ether, 15 ether
+        );
+        vm.prank(requester);
+        moo.setReward(IDENTIFIER, t, ANCILLARY, 15 ether);
+        assertEq(currency.balanceOf(requester), requesterBalance - 5 ether);
+        assertEq(currency.balanceOf(address(moo)), oracleBalance + 5 ether);
+
+        requesterBalance = currency.balanceOf(requester);
+        oracleBalance = currency.balanceOf(address(moo));
+        vm.prank(requester);
+        moo.setReward(IDENTIFIER, t, ANCILLARY, 4 ether);
+        assertEq(currency.balanceOf(requester), requesterBalance + 11 ether);
+        assertEq(currency.balanceOf(address(moo)), oracleBalance - 11 ether);
+
+        vm.prank(requester);
+        moo.setReward(IDENTIFIER, t, ANCILLARY, 0);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).reward, 0);
+        assertEq(
+            uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Requested)
+        );
+
+        _proposeFor(sender, proposer, requester, t, 42);
+        assertEq(
+            uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Proposed)
+        );
+    }
+
+    function testRequestManagerSetRewardUsesCallerFundsAndRefundsRequester() external {
+        uint256 t = moo.getCurrentTime();
+        _makeRequest(requester, t, 10 ether);
+        currency.mint(requester, 100 ether);
+        _prepareFunds(requestManager);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), moo.REQUEST_MANAGER_ROLE()
+            )
+        );
+        moo.requestManagerSetReward(requester, IDENTIFIER, t, ANCILLARY, 11 ether);
+
+        vm.prank(requestManager);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.requestManagerSetReward(requester, IDENTIFIER, t + 1, ANCILLARY, 11 ether);
+
+        uint256 requesterBalance = currency.balanceOf(requester);
+        uint256 managerBalance = currency.balanceOf(requestManager);
+        uint256 oracleBalance = currency.balanceOf(address(moo));
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.RewardUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, requestManager, 10 ether, 16 ether
+        );
+        vm.prank(requestManager);
+        moo.requestManagerSetReward(requester, IDENTIFIER, t, ANCILLARY, 16 ether);
+        assertEq(currency.balanceOf(requester), requesterBalance);
+        assertEq(currency.balanceOf(requestManager), managerBalance - 6 ether);
+        assertEq(currency.balanceOf(address(moo)), oracleBalance + 6 ether);
+
+        requesterBalance = currency.balanceOf(requester);
+        managerBalance = currency.balanceOf(requestManager);
+        oracleBalance = currency.balanceOf(address(moo));
+        vm.prank(requestManager);
+        moo.requestManagerSetReward(requester, IDENTIFIER, t, ANCILLARY, 4 ether);
+        assertEq(currency.balanceOf(requester), requesterBalance + 12 ether);
+        assertEq(currency.balanceOf(requestManager), managerBalance);
+        assertEq(currency.balanceOf(address(moo)), oracleBalance - 12 ether);
+
+        vm.prank(requestManager);
+        moo.requestManagerSetReward(requester, IDENTIFIER, t, ANCILLARY, 0);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).reward, 0);
+        assertEq(currency.balanceOf(requestManager), managerBalance);
+        assertEq(currency.balanceOf(requester), requesterBalance + 16 ether);
+    }
+
+    function testRewardUpdatesRevertAfterProposal() external {
+        uint256 t = moo.getCurrentTime();
+        _makeRequest(requester, t, 1 ether);
+        _proposeFor(sender, proposer, requester, t, 42);
+
+        vm.prank(requester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setReward(IDENTIFIER, t, ANCILLARY, 0);
+
+        vm.prank(requestManager);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.requestManagerSetReward(requester, IDENTIFIER, t, ANCILLARY, 0);
+    }
+
     // -------------------- Liveness Management --------------------
 
     function testSetMinimumDisputeWindowAndValidation() external {
@@ -938,23 +1040,25 @@ contract ManagedOptimisticOracleV2Test is Test {
         uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
-        // Disable whitelist per-request
+        // A real enabled whitelist with no members pauses proposals.
+        AddressWhitelist emptyWhitelist = new AddressWhitelist();
         vm.prank(requestManager);
-        moo.requestManagerSetProposerWhitelist(requester, IDENTIFIER, ANCILLARY, address(disabledWhitelist));
+        moo.requestManagerSetProposerWhitelist(requester, IDENTIFIER, ANCILLARY, address(emptyWhitelist));
+        _prepareFunds(sender);
+        vm.prank(sender);
+        vm.expectRevert(ManagedOptimisticOracleV2Interface.ProposerNotWhitelisted.selector);
+        moo.proposePriceFor(proposer, requester, IDENTIFIER, t, ANCILLARY, 7);
+        assertEq(
+            uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Requested)
+        );
 
-        // Any addresses can propose
-        address freeSender = makeAddr("freeSender");
-        address freeProposer = makeAddr("freeProposer");
-        _proposeFor(freeSender, freeProposer, requester, t, 7);
-
-        // Reset to default by setting zero address
+        // Zero restores the default whitelist rather than cancelling the request.
         vm.prank(requestManager);
         moo.requestManagerSetProposerWhitelist(requester, IDENTIFIER, ANCILLARY, address(0));
-
-        // Now free addresses should be blocked by default whitelist (first check proposer)
-        vm.prank(freeSender);
-        vm.expectRevert(ManagedOptimisticOracleV2Interface.ProposerNotWhitelisted.selector);
-        moo.proposePriceFor(freeProposer, requester, IDENTIFIER, t + 1, ANCILLARY, 1);
+        _proposeFor(sender, proposer, requester, t, 7);
+        assertEq(
+            uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Proposed)
+        );
     }
 
     function testAllowedBondRangeEventAndBehavior() external {

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -651,7 +651,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
         vm.prank(requester);
         moo.setReward(IDENTIFIER, t, ANCILLARY, 0);
-        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).reward, 0);
+        assertEq(moo.getRequestReward(requester, IDENTIFIER, t, ANCILLARY), 0);
         assertEq(
             uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Requested)
         );

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -578,13 +578,38 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.requestManagerSetBond(requester, IDENTIFIER, ANCILLARY, IERC20(address(otherCurrency)), 1);
     }
 
+    function testRequesterSetBondEventsAndLifecycle() external {
+        uint256 t = moo.getCurrentTime();
+        _makeRequest(requester, t, 0);
+
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.BondUpdated(requester, IDENTIFIER, t, ANCILLARY, 10 ether, 3 ether);
+        vm.prank(requester);
+        assertEq(moo.setBond(IDENTIFIER, t, ANCILLARY, 3 ether), 13 ether);
+
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.BondUpdated(requester, IDENTIFIER, t, ANCILLARY, 3 ether, 4 ether);
+        vm.prank(requester);
+        assertEq(moo.setBond(IDENTIFIER, t, ANCILLARY, 4 ether), 14 ether);
+
+        _proposeFor(sender, proposer, requester, t, 100);
+
+        vm.prank(requester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setBond(IDENTIFIER, t, ANCILLARY, 5 ether);
+    }
+
     function testCustomBondAppliedOnPropose() external {
         uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
+        vm.prank(requester);
+        moo.setBond(IDENTIFIER, t, ANCILLARY, 3 ether);
+
         // Set custom bond of 5 ether
         vm.prank(requestManager);
         moo.requestManagerSetBond(requester, IDENTIFIER, ANCILLARY, IERC20(address(currency)), 5 ether);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).requestSettings.bond, 3 ether);
 
         // Propose and verify total bond = custom bond + final fee (10 ether)
         uint256 totalBond = _proposeFor(sender, proposer, requester, t, 100);
@@ -804,12 +829,16 @@ contract ManagedOptimisticOracleV2Test is Test {
         vm.expectRevert(OptimisticOracleV2Interface.LivenessTooLarge.selector);
         moo.requestManagerSetCustomLiveness(requester, IDENTIFIER, ANCILLARY, 5200 weeks);
 
+        vm.prank(requester);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 1 hours);
+
         // Valid set and event
         vm.expectEmit(true, true, true, true);
         bytes32 managedId = moo.getManagedRequestId(requester, IDENTIFIER, ANCILLARY);
         emit ManagedOptimisticOracleV2Interface.CustomLivenessSet(managedId, requester, IDENTIFIER, ANCILLARY, 3 hours);
         vm.prank(requestManager);
         moo.requestManagerSetCustomLiveness(requester, IDENTIFIER, ANCILLARY, 3 hours);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).requestSettings.customLiveness, 1 hours);
 
         // Propose and check expiration time = now + 3 hours
         vm.warp(t + 10);
@@ -818,7 +847,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(req.expirationTime, moo.getCurrentTime() + 3 hours);
     }
 
-    function testRequesterSetCustomLivenessValidation() external {
+    function testRequesterSetCustomLivenessValidationEventsAndLifecycle() external {
         uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
@@ -833,14 +862,29 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 5200 weeks);
 
         // Valid set at minimum dispute window
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.CustomLivenessUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, 0, MINIMUM_DISPUTE_WINDOW
+        );
         vm.prank(requester);
         moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, MINIMUM_DISPUTE_WINDOW);
 
-        // Propose and check expiration time = now + MINIMUM_DISPUTE_WINDOW
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.CustomLivenessUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, MINIMUM_DISPUTE_WINDOW, 1 hours
+        );
+        vm.prank(requester);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 1 hours);
+
+        // Propose and check expiration time = now + custom liveness
         vm.warp(t + 10);
         _proposeFor(sender, proposer, requester, t, 123);
         OptimisticOracleV2Interface.Request memory req = moo.getRequest(requester, IDENTIFIER, t, ANCILLARY);
-        assertEq(req.expirationTime, moo.getCurrentTime() + MINIMUM_DISPUTE_WINDOW);
+        assertEq(req.expirationTime, moo.getCurrentTime() + 1 hours);
+
+        vm.prank(requester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 2 hours);
     }
 
     // -------------------- Utility --------------------


### PR DESCRIPTION
## Feature

FRO-106 adds a reversible pre-proposal pause and reward-recovery flow for active Managed OO requests. This is an additional Retainer 07 feature rather than an audit finding.

References: [FRO-106](https://linear.app/uma/issue/FRO-106/oz-retainer-07feature-add-reversible-pre-proposal-cancellation-and) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Add requester and request-manager reward setters that are available only while a request is in `Requested`.
- Pull reward increases from the caller and return reductions to the original requester, using the existing deferred-payout path when a transfer fails.
- Add the reporter initializer path, fund only the effective delta, and synchronize its cache from the Managed OO request and dispute refund.
- Preserve zero-reward proposal semantics: pausing uses a real enabled proposer whitelist with no members; `address(0)` restores the default whitelist, while `DisabledAddressWhitelist` remains permissionless.
- Document the pause/restore order, proposal race, timestamp-independent whitelist persistence, initializer reward caps, and working-balance guidance.
- Lower the root optimizer runs from 25 to 1 to keep `ManagedOptimisticOracleV2` deployable under EIP-170.

## Validation

- `forge test --match-contract 'ManagedOptimisticOracleV2Test|DeferredPayoutTest'` — 73 tests passed
- Polygon fork suites — 15 tests passed
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 45 tests passed
- `forge build --sizes` — `ManagedOptimisticOracleV2` 24,319 B (257 B margin)
- `cd pm-v2-oo-reporter && forge build --sizes --optimize false` — `OOReporter` 24,490 B (86 B margin)
- `cd pm-v2-oo-reporter && forge fmt --check`
- `git diff --check`