### PR TITLE
feat[oz-retainer-07]: emit bond and liveness update events

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -84,6 +84,16 @@ Lifecycle events that refer to a specific Managed OO request consistently lead w
 the active OO `requestTimestamp` before actor or outcome fields. This keeps initialization, re-request,
 re-request-gate, rules-update, and resolution logs easy to correlate after a request has been replaced.
 
+## Bond And Liveness Events
+
+`BondUpdated` and `CustomLivenessUpdated` expose requester-controlled changes to the concrete Managed OO request. Each
+request starts with a bond equal to its `finalFee` and custom liveness equal to `0`, so the first update event for each
+setting reports that default as its old value.
+
+To reconstruct the effective bond and liveness at proposal time, consumers must combine those events with
+`CustomBondSet` and `CustomLivenessSet`. These request-manager overrides take precedence when `proposePriceFor(...)`
+applies the proposal settings, even if the requester changed the concrete request afterward.
+
 ## Reward Updates And Pre-Proposal Pauses
 
 Any enabled oracle initializer can call `setRequestReward(requestId, newReward)` while the active Managed OO request is

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -238,7 +238,9 @@ contract OptimisticOracleV2 is
         returns (uint256 totalBond)
     {
         Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
+        uint256 oldBond = request.requestSettings.bond;
         request.requestSettings.bond = bond;
+        emit BondUpdated(msg.sender, identifier, timestamp, ancillaryData, oldBond, bond);
 
         // Total bond is the final fee + the newly set bond.
         return bond + request.finalFee;
@@ -296,7 +298,9 @@ contract OptimisticOracleV2 is
     ) external override nonReentrant {
         Request storage request = _getRequestedRequest(msg.sender, identifier, timestamp, ancillaryData);
         _validateLiveness(customLiveness);
+        uint256 oldCustomLiveness = request.requestSettings.customLiveness;
         request.requestSettings.customLiveness = customLiveness;
+        emit CustomLivenessUpdated(msg.sender, identifier, timestamp, ancillaryData, oldCustomLiveness, customLiveness);
     }
 
     /**

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -62,6 +62,36 @@ abstract contract OptimisticOracleV2Interface {
         uint256 oldReward,
         uint256 newReward
     );
+    /// @notice Emitted when the proposal bond associated with a price request is updated.
+    /// @param requester sender of the initial price request.
+    /// @param identifier price identifier identifying the existing request.
+    /// @param timestamp timestamp identifying the existing request.
+    /// @param ancillaryData ancillary data of the price being requested.
+    /// @param oldBond previous custom bond amount.
+    /// @param newBond new custom bond amount.
+    event BondUpdated(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        uint256 oldBond,
+        uint256 newBond
+    );
+    /// @notice Emitted when the custom liveness associated with a price request is updated.
+    /// @param requester sender of the initial price request.
+    /// @param identifier price identifier identifying the existing request.
+    /// @param timestamp timestamp identifying the existing request.
+    /// @param ancillaryData ancillary data of the price being requested.
+    /// @param oldCustomLiveness previous custom liveness value.
+    /// @param newCustomLiveness new custom liveness value.
+    event CustomLivenessUpdated(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        uint256 oldCustomLiveness,
+        uint256 newCustomLiveness
+    );
     event ProposePrice(
         address indexed requester,
         address indexed proposer,

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -578,13 +578,38 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.requestManagerSetBond(requester, IDENTIFIER, ANCILLARY, IERC20(address(otherCurrency)), 1);
     }
 
+    function testRequesterSetBondEventsAndLifecycle() external {
+        uint256 t = moo.getCurrentTime();
+        _makeRequest(requester, t, 0);
+
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.BondUpdated(requester, IDENTIFIER, t, ANCILLARY, 10 ether, 3 ether);
+        vm.prank(requester);
+        assertEq(moo.setBond(IDENTIFIER, t, ANCILLARY, 3 ether), 13 ether);
+
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.BondUpdated(requester, IDENTIFIER, t, ANCILLARY, 3 ether, 4 ether);
+        vm.prank(requester);
+        assertEq(moo.setBond(IDENTIFIER, t, ANCILLARY, 4 ether), 14 ether);
+
+        _proposeFor(sender, proposer, requester, t, 100);
+
+        vm.prank(requester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setBond(IDENTIFIER, t, ANCILLARY, 5 ether);
+    }
+
     function testCustomBondAppliedOnPropose() external {
         uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
+        vm.prank(requester);
+        moo.setBond(IDENTIFIER, t, ANCILLARY, 3 ether);
+
         // Set custom bond of 5 ether
         vm.prank(requestManager);
         moo.requestManagerSetBond(requester, IDENTIFIER, ANCILLARY, IERC20(address(currency)), 5 ether);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).requestSettings.bond, 3 ether);
 
         // Propose and verify total bond = custom bond + final fee (10 ether)
         uint256 totalBond = _proposeFor(sender, proposer, requester, t, 100);
@@ -804,12 +829,16 @@ contract ManagedOptimisticOracleV2Test is Test {
         vm.expectRevert(OptimisticOracleV2Interface.LivenessTooLarge.selector);
         moo.requestManagerSetCustomLiveness(requester, IDENTIFIER, ANCILLARY, 5200 weeks);
 
+        vm.prank(requester);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 1 hours);
+
         // Valid set and event
         vm.expectEmit(true, true, true, true);
         bytes32 managedId = moo.getManagedRequestId(requester, IDENTIFIER, ANCILLARY);
         emit ManagedOptimisticOracleV2Interface.CustomLivenessSet(managedId, requester, IDENTIFIER, ANCILLARY, 3 hours);
         vm.prank(requestManager);
         moo.requestManagerSetCustomLiveness(requester, IDENTIFIER, ANCILLARY, 3 hours);
+        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).requestSettings.customLiveness, 1 hours);
 
         // Propose and check expiration time = now + 3 hours
         vm.warp(t + 10);
@@ -818,7 +847,7 @@ contract ManagedOptimisticOracleV2Test is Test {
         assertEq(req.expirationTime, moo.getCurrentTime() + 3 hours);
     }
 
-    function testRequesterSetCustomLivenessValidation() external {
+    function testRequesterSetCustomLivenessValidationEventsAndLifecycle() external {
         uint256 t = moo.getCurrentTime();
         _makeRequest(requester, t, 0);
 
@@ -833,14 +862,29 @@ contract ManagedOptimisticOracleV2Test is Test {
         moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 5200 weeks);
 
         // Valid set at minimum dispute window
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.CustomLivenessUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, 0, MINIMUM_DISPUTE_WINDOW
+        );
         vm.prank(requester);
         moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, MINIMUM_DISPUTE_WINDOW);
 
-        // Propose and check expiration time = now + MINIMUM_DISPUTE_WINDOW
+        vm.expectEmit(true, false, false, true);
+        emit OptimisticOracleV2Interface.CustomLivenessUpdated(
+            requester, IDENTIFIER, t, ANCILLARY, MINIMUM_DISPUTE_WINDOW, 1 hours
+        );
+        vm.prank(requester);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 1 hours);
+
+        // Propose and check expiration time = now + custom liveness
         vm.warp(t + 10);
         _proposeFor(sender, proposer, requester, t, 123);
         OptimisticOracleV2Interface.Request memory req = moo.getRequest(requester, IDENTIFIER, t, ANCILLARY);
-        assertEq(req.expirationTime, moo.getCurrentTime() + MINIMUM_DISPUTE_WINDOW);
+        assertEq(req.expirationTime, moo.getCurrentTime() + 1 hours);
+
+        vm.prank(requester);
+        vm.expectRevert(OptimisticOracleV2Interface.RequestStateNotRequested.selector);
+        moo.setCustomLiveness(IDENTIFIER, t, ANCILLARY, 2 hours);
     }
 
     // -------------------- Utility --------------------


### PR DESCRIPTION
## Audit remediation feature

Managed OO requester-set bond and custom liveness changes currently mutate request settings without oracle-side events. This additional Retainer 07 feature makes those changes observable while preserving the request-manager override behavior.

This PR is built on [#56](https://github.com/UMAprotocol/managed-oracle/pull/56), which provides the event pattern and optimizer setting required for the available EIP-170 margin.

References: [FRO-109](https://linear.app/uma/issue/FRO-109/oz-retainer-07feature-emit-missing-bond-and-liveness-change-events) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Add `BondUpdated` and `CustomLivenessUpdated` with the concrete request tuple and old/new values.
- Emit each event after the requester-controlled setting is updated.
- Cover initial defaults, subsequent updates, lifecycle restrictions, and request-manager override precedence.
- Document how consumers combine requester events with request-manager override events to derive effective proposal settings.

## Validation

- `forge test --match-contract 'ManagedOptimisticOracleV2Test|DeferredPayoutTest'` — 74 tests passed
- Polygon fork suites — 15 tests passed
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 45 tests passed
- `forge build --sizes` — `ManagedOptimisticOracleV2` 24,469 B (107 B margin)
- `cd pm-v2-oo-reporter && forge fmt --check`
- `git diff --check`