### PR TITLE
fix[oz-retainer-07-n-02]: uppercase oracle constants

### DIFF
--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -57,7 +57,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
     }
 
     // keccak256(abi.encode(uint256(keccak256("uma.storage.OOReporter")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant OOReporterStorageLocation =
+    bytes32 private constant OO_REPORTER_STORAGE_LOCATION =
         0xe597f8c3629f5ca2bbd4f416c338811ff317bd2d6db5ce34f2567207506cc400;
 
     /*--------------------------------------------------------------
@@ -71,7 +71,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
     function _getStorage() private pure returns (OOReporterStorage storage $) {
         assembly {
-            $.slot := OOReporterStorageLocation
+            $.slot := OO_REPORTER_STORAGE_LOCATION
         }
     }
 

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -93,7 +93,7 @@ contract OptimisticOracleV2 is
 
     // This is effectively the extra ancillary data to add ",ooRequester:0000000000000000000000000000000000000000".
     uint256 private constant MAX_ADDED_ANCILLARY_DATA = 53;
-    uint256 public constant OO_ANCILLARY_DATA_LIMIT = ancillaryBytesLimit - MAX_ADDED_ANCILLARY_DATA;
+    uint256 public constant OO_ANCILLARY_DATA_LIMIT = ANCILLARY_BYTES_LIMIT - MAX_ADDED_ANCILLARY_DATA;
     int256 public constant TOO_EARLY_RESPONSE = type(int256).min;
 
     // Mapping of collateral currency to deferred payout recipient and to their outstanding payouts. Used when reward

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -129,6 +129,12 @@ abstract contract OptimisticOracleV2Interface {
     // to accept a price request made with ancillary data length over a certain size.
     uint256 public constant ANCILLARY_BYTES_LIMIT = 8192;
 
+    /// @notice Deprecated compatibility getter. Use `ANCILLARY_BYTES_LIMIT()` instead.
+    /// @dev Preserves the selector published by earlier OptimisticOracleV2 deployments.
+    function ancillaryBytesLimit() external pure returns (uint256) {
+        return ANCILLARY_BYTES_LIMIT;
+    }
+
     function defaultLiveness() external view virtual returns (uint256);
 
     function finder() external view virtual returns (FinderInterface);

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -127,7 +127,7 @@ abstract contract OptimisticOracleV2Interface {
     // This value must be <= the Voting contract's `ancillaryBytesLimit` value otherwise it is possible
     // that a price can be requested to this contract successfully, but cannot be disputed because the DVM refuses
     // to accept a price request made with ancillary data length over a certain size.
-    uint256 public constant ancillaryBytesLimit = 8192;
+    uint256 public constant ANCILLARY_BYTES_LIMIT = 8192;
 
     function defaultLiveness() external view virtual returns (uint256);
 


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### N-02 — Constants Not Using `UPPER_CASE` Format
>
> - Severity: Notes
> - Status: Open
>
> `OOReporterStorageLocation` in `OOReporter.sol` and `ancillaryBytesLimit` in `OptimisticOracleV2Interface.sol` do not follow Solidity's uppercase-with-underscores convention for constants.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-101](https://linear.app/uma/issue/FRO-101/oz-retainer-07n-02-constants-not-using-upper-case-format) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Rename `OOReporterStorageLocation` to `OO_REPORTER_STORAGE_LOCATION` and update its assembly reference.
- Add `ANCILLARY_BYTES_LIMIT` and update the `OO_ANCILLARY_DATA_LIMIT` derivation to use it.
- Preserve the legacy `ancillaryBytesLimit()` selector through a deprecated compatibility getter.
- Preserve both constant values and the ERC-7201 storage slot unchanged.
- The private storage constant rename has no behavior, ABI, or storage-layout impact; the public uppercase getter is additive and the legacy getter remains callable.

## Validation

- `forge fmt --check` — passed in CI with Foundry 1.3.6
- `forge build --sizes`
- `forge test -vvv --no-match-contract ".*Fork.*"` — 77 tests passed
- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 39 tests passed
- `git diff --check`
