### PR TITLE
fix[oz-retainer-07-n-03]: add two-step OOReporter ownership

### DIFF
--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -27,6 +27,8 @@ contract OOReporter is
 {
     using SafeERC20 for IERC20;
 
+    error OwnershipRenunciationDisabled();
+
     /*--------------------------------------------------------------
                              CONSTANTS
     --------------------------------------------------------------*/
@@ -132,6 +134,11 @@ contract OOReporter is
         $.automaticRerequestsEnabled = true;
         emit DefaultRerequestBudgetSet(initialDefaultRerequestBudget);
         emit AutomaticRerequestsEnabledSet(true);
+    }
+
+    /// @notice Ownership renunciation is disabled to preserve administrative and upgrade authority.
+    function renounceOwnership() public pure override {
+        revert OwnershipRenunciationDisabled();
     }
 
     /// @notice Returns the configured Managed Optimistic Oracle V2 address.

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.34;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {MulticallUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -18,7 +18,13 @@ import {IOptimisticRequester} from "./interfaces/IOptimisticRequester.sol";
 ///      then this reporter stores the final raw UMA price for market-side translation. Enabled requesters
 ///      share one owner-managed request namespace and are expected to coordinate on request identity.
 /// @custom:security-contact bugs@umaproject.org
-contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable, IOOReporter, IOptimisticRequester {
+contract OOReporter is
+    Ownable2StepUpgradeable,
+    UUPSUpgradeable,
+    MulticallUpgradeable,
+    IOOReporter,
+    IOptimisticRequester
+{
     using SafeERC20 for IERC20;
 
     /*--------------------------------------------------------------
@@ -108,6 +114,7 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
         }
 
         __Ownable_init(initialOwner);
+        __Ownable2Step_init();
         __Multicall_init();
 
         OOReporterStorage storage $ = _getStorage();

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -124,6 +124,26 @@ contract OOReporterTest {
         reporter = OOReporter(address(new SimpleProxy(address(implementation), initData)));
     }
 
+    function test_transferOwnershipRequiresPendingOwnerAcceptance() external {
+        vm.prank(owner);
+        reporter.transferOwnership(unauthorized);
+
+        assertEq(reporter.owner(), owner, "owner should remain until acceptance");
+        assertEq(reporter.pendingOwner(), unauthorized, "incorrect pending owner");
+
+        vm.prank(owner);
+        reporter.transferOwnership(secondRequester);
+
+        assertEq(reporter.owner(), owner, "owner should remain after replacing nominee");
+        assertEq(reporter.pendingOwner(), secondRequester, "replacement pending owner mismatch");
+
+        vm.prank(secondRequester);
+        reporter.acceptOwnership();
+
+        assertEq(reporter.owner(), secondRequester, "accepted owner mismatch");
+        assertEq(reporter.pendingOwner(), address(0), "pending owner should clear");
+    }
+
     function test_registerRequestStoresRequestWithoutInitializerSuffix() external {
         bytes memory requestRules = _requestRules("primary");
 

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -144,6 +144,14 @@ contract OOReporterTest {
         assertEq(reporter.pendingOwner(), address(0), "pending owner should clear");
     }
 
+    function test_renounceOwnershipIsDisabled() external {
+        vm.prank(owner);
+        vm.expectRevert(OOReporter.OwnershipRenunciationDisabled.selector);
+        reporter.renounceOwnership();
+
+        assertEq(reporter.owner(), owner, "owner should remain");
+    }
+
     function test_registerRequestStoresRequestWithoutInitializerSuffix() external {
         bytes memory requestRules = _requestRules("primary");
 


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### N-03 — Single-Step Ownership Transfer Can Lead to Accidental Loss Of Admin Control
>
> - Severity: Notes
> - Status: Open
>
> `OOReporter` transfers ownership immediately without requiring the nominated address to accept it. A typo or incorrectly pasted address can therefore permanently transfer ownership to an inaccessible account and lose administrative control.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-103](https://linear.app/uma/issue/FRO-103/oz-retainer-07n-03-single-step-ownership-transfer-can-lead-to) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Replace `OwnableUpgradeable` with `Ownable2StepUpgradeable`.
- Keep the current owner in control until the nominated `pendingOwner` calls `acceptOwnership()`.
- Allow the current owner to replace an incorrect pending nominee before acceptance.
- Disable `renounceOwnership()` so the reporter cannot accidentally lose its administrative, recovery, and upgrade authority.
- Preserve the existing owner slot and store the pending owner in OpenZeppelin's separate ERC-7201 namespace.
- Add focused coverage for nomination, replacement, acceptance, and disabled ownership renunciation.

Ownership handoffs now require the nominated account, including a Safe, to execute the second acceptance transaction.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge build --sizes` — `OOReporter` runtime is 24,088 bytes, leaving 488 bytes below the EIP-170 limit
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol --match-test test_renounceOwnershipIsDisabled` — 1 test passed
- `cd pm-v2-oo-reporter && forge test` — 41 tests passed
- `git diff --check`
