### PR TITLE
docs[oz-retainer-07-n-05]: document identifier de-whitelisting backstops

### DIFF
--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -526,6 +526,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             }
         }
 
+        // Managed OO validates identifier support only when creating this request. If governance removes it later,
+        // resolver-gated settlement and Polymarket's administrator/arbitrator `resolveResult` remain the backstops.
         oracle.requestPrice(priceIdentifier, requestTimestamp, requestRules, currency, reward);
         oracle.setEventBased(priceIdentifier, requestTimestamp, requestRules);
         oracle.setCallbacks(priceIdentifier, requestTimestamp, requestRules, false, true, true);


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### N-05 — De-Whitelisting a Price Identifier Mid-Request Can Render It Undisputable
>
> - Severity: Notes
> - Status: Open
>
> Identifier support is checked only when creating a request. If governance de-whitelists it afterward, a dispute can no longer reach the DVM, potentially leaving the request without a valid dispute path.

References: [OpenZeppelin audit findings](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues) · [FRO-105](https://linear.app/uma/issue/FRO-105/oz-retainer-07n-05-de-whitelisting-a-price-identifier-mid-request-can) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Document at the Managed OO request site that identifier support is validated only when the request is created.
- Document the intended operational backstops for later de-whitelisting: resolver-gated settlement and the Polymarket administrator/arbitrator `resolveResult` override.
- Retain the existing request, proposal, dispute, and settlement behavior.
- Documentation-only change: no behavior, ABI, event/error signature, or storage changes.

## Validation

- `cd pm-v2-oo-reporter && forge fmt --check`
- `cd pm-v2-oo-reporter && forge build --sizes` — `OOReporter` runtime is 23,605 bytes, leaving 971 bytes below the EIP-170 limit
- `cd pm-v2-oo-reporter && forge test -vvv` — 39 tests passed
- `git diff --check`
