### PR TITLE
docs[oz-retainer-07-l-04]: document reward counterparties

### DIFF
--- a/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol
@@ -74,7 +74,9 @@ abstract contract ManagedOptimisticOracleV2Interface {
     /**
      * @notice Updates the reward for a concrete price request.
      * @dev Only callable by a request manager while the request is in the Requested state. Reward increases are
-     * funded by the caller, while decreases are always refunded to the original requester.
+     * funded by the caller, while decreases are always refunded to the original requester. Consequently, a request
+     * manager cannot recover an over-funded reward; only the original requester receives funds returned by a later
+     * decrease.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identify the concrete request round.


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### L-04 — Reward Increases and Decreases Use Asymmetric Counterparties, Preventing Recovery of Over-Funding
>
> - Severity: Low
> - Status: Open
>
> `requestManagerSetReward` pulls reward increases from the request manager but refunds decreases to the original requester. A manager therefore cannot recover an accidental over-increase, and the interface should make that asymmetry explicit.

This PR is built on [#56](https://github.com/UMAprotocol/managed-oracle/pull/56), which introduces the reward-update path reviewed by this finding.

References: [OpenZeppelin audit finding](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues/reward-increases-and-decreases-use-asymmetric-counterparties-preventing-recovery-of-over-funding-b1be1ce9) · [FRO-113](https://linear.app/uma/issue/FRO-113/oz-retainer-07l-04-reward-increases-and-decreases-use-asymmetric) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Clarify the `requestManagerSetReward` interface NatSpec that reward increases are funded by the manager while decreases return funds only to the original requester.
- State explicitly that lowering the reward cannot recover an amount previously over-funded by the request manager.
- Preserve the existing reward-accounting behavior.
- Documentation-only change: no behavior, ABI, event/error signature, or storage changes.

## Validation

- `forge fmt --check src/optimistic-oracle-v2/interfaces/ManagedOptimisticOracleV2Interface.sol`
- `forge test --match-test testRequestManagerSetRewardUsesCallerFundsAndRefundsRequester` — 1 test passed
- `git diff --check`