### PR TITLE
fix[oz-retainer-07-l-05]: replace hardcoded reward decode

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -90,7 +90,8 @@ Any enabled oracle initializer can call `setRequestReward(requestId, newReward)`
 still waiting for a proposal. The caller does not need to be the initializer that created the active request. Increasing
 the reward pulls only the delta from the reporter's reward balance; decreasing it, including setting it to zero, refunds
 the delta to the reporter or credits a deferred payout if the token transfer fails. The reporter updates its cached
-reward only after Managed OO accepts the change, so later automatic re-requests reuse the updated amount.
+reward before calling Managed OO so callbacks observe the new amount. If the oracle rejects the change, the transaction
+reverts the cache update as well; successful changes are reused by later automatic re-requests.
 
 Because enabled initializers can spend the reporter's reward balance, initializer infrastructure should enforce an
 operational maximum reward and the reporter should hold only the working balance needed for requests rather than a

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -262,8 +262,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             _prepareReward(currency, oracle, newReward - oldReward);
         }
 
-        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
         request.reward = newReward;
+        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
 
         emit RequestRewardUpdated(
             requestId, request.requestTimestamp, msg.sender, address(currency), oldReward, newReward

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -255,22 +255,9 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
 
         IERC20 currency = rewardCurrency();
         IOptimisticOracleV2 oracle = optimisticOracle();
-        bytes memory callData = abi.encodeCall(
-            IOptimisticOracleV2.getRequest,
-            (address(this), request.priceIdentifier, request.requestTimestamp, request.requestRules)
+        uint256 oldReward = oracle.getRequestReward(
+            address(this), request.priceIdentifier, request.requestTimestamp, request.requestRules
         );
-        uint256 oldReward;
-        // Decode only Request.reward (word 14, requiring 15 words / 0x1e0 bytes) to stay below EIP-170.
-        assembly {
-            let result := mload(0x40)
-            mstore(0x40, add(result, 0x220))
-            if iszero(staticcall(gas(), oracle, add(callData, 0x20), mload(callData), result, 0x220)) {
-                returndatacopy(result, 0, returndatasize())
-                revert(result, returndatasize())
-            }
-            if lt(returndatasize(), 0x1e0) { revert(0, 0) }
-            oldReward := mload(add(result, 0x1c0))
-        }
         if (newReward > oldReward) {
             _prepareReward(currency, oracle, newReward - oldReward);
         }

--- a/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/src/interfaces/IOptimisticOracleV2.sol
@@ -123,6 +123,17 @@ interface IOptimisticOracleV2 {
     /// @param updatedRules Updated request rules to record for the request.
     function updateRequestRules(bytes32 identifier, bytes memory requestRules, bytes memory updatedRules) external;
 
+    /// @notice Gets the current reward for an OO request tuple.
+    /// @param requester Sender of the initial price request.
+    /// @param identifier Price identifier to identify the existing request.
+    /// @param timestamp Timestamp to identify the existing request.
+    /// @param requestRules Request rules of the price being requested.
+    /// @return reward Current reward amount.
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        view
+        returns (uint256 reward);
+
     /// @notice Gets current request data for an OO request tuple.
     /// @param requester Sender of the initial price request.
     /// @param identifier Price identifier to identify the existing request.

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -395,6 +395,7 @@ contract OOReporterTest {
 
         vm.prank(address(reporter));
         usdc.approve(address(optimisticOracle), 0);
+        optimisticOracle.expectReporterRewardDuringSetReward(REQUEST_ID, REREQUEST_REWARD);
 
         vm.expectEmit(address(reporter));
         emit RequestRewardUpdated(

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -5,6 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {IOptimisticOracleV2} from "src/interfaces/IOptimisticOracleV2.sol";
 import {IOptimisticRequester} from "src/interfaces/IOptimisticRequester.sol";
+import {IOOReporter} from "src/interfaces/IOOReporter.sol";
 
 contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     struct MockRequest {
@@ -32,6 +33,8 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     mapping(IERC20 currency => mapping(address deferredRecipient => uint256 amount)) public deferredPayouts;
     uint256 public minimumDisputeWindow = 5 minutes;
     bool public deferNextDisputeRefund;
+    bytes32 private expectedRewardRequestId;
+    uint256 private expectedReporterReward;
 
     function getMockRequest(bytes32 key) external view returns (MockRequest memory) {
         return requests[key];
@@ -237,9 +240,22 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         minimumDisputeWindow = newMinimumDisputeWindow;
     }
 
+    function expectReporterRewardDuringSetReward(bytes32 requestId, uint256 reward) external {
+        expectedRewardRequestId = requestId;
+        expectedReporterReward = reward;
+    }
+
     function _setReward(MockRequest storage request, address requester, uint256 newReward) private {
         require(request.requested, "not requested");
         require(!request.proposed, "already proposed");
+
+        if (expectedRewardRequestId != bytes32(0)) {
+            require(
+                IOOReporter(requester).getRequest(expectedRewardRequestId).reward == expectedReporterReward,
+                "reporter reward not updated"
+            );
+            expectedRewardRequestId = bytes32(0);
+        }
 
         uint256 oldReward = request.reward;
         request.reward = newReward;

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -69,6 +69,14 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         });
     }
 
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        view
+        returns (uint256 reward)
+    {
+        return requests[requestKey(requester, identifier, timestamp, requestRules)].reward;
+    }
+
     function requestKey(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
         public
         pure

--- a/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
+++ b/src/optimistic-oracle-v2/implementation/OptimisticOracleV2.sol
@@ -586,6 +586,17 @@ contract OptimisticOracleV2 is
         emit ClaimedDeferredPayout(address(currency), deferredRecipient, repaymentAddress, amount);
     }
 
+    /// @inheritdoc OptimisticOracleV2Interface
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory ancillaryData)
+        public
+        view
+        override
+        nonReentrantView
+        returns (uint256 reward)
+    {
+        return _getRequest(requester, identifier, timestamp, ancillaryData).reward;
+    }
+
     /**
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.

--- a/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
+++ b/src/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol
@@ -364,6 +364,20 @@ abstract contract OptimisticOracleV2Interface {
     function claimDeferredPayout(IERC20 currency, address repaymentAddress) external virtual;
 
     /**
+     * @notice Gets the current reward for a price request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return reward current reward amount.
+     */
+    function getRequestReward(address requester, bytes32 identifier, uint256 timestamp, bytes memory ancillaryData)
+        public
+        view
+        virtual
+        returns (uint256 reward);
+
+    /**
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.

--- a/test/ManagedOptimisticOracleV2.t.sol
+++ b/test/ManagedOptimisticOracleV2.t.sol
@@ -626,7 +626,7 @@ contract ManagedOptimisticOracleV2Test is Test {
 
         vm.prank(requester);
         moo.setReward(IDENTIFIER, t, ANCILLARY, 0);
-        assertEq(moo.getRequest(requester, IDENTIFIER, t, ANCILLARY).reward, 0);
+        assertEq(moo.getRequestReward(requester, IDENTIFIER, t, ANCILLARY), 0);
         assertEq(
             uint8(moo.getState(requester, IDENTIFIER, t, ANCILLARY)), uint8(OptimisticOracleV2Interface.State.Requested)
         );


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### L-05 — Hardcoded Assembly Offset in `setRequestReward` Can Misread the Reward if the Request Layout Changes
>
> - Severity: Low
> - Status: Open
>
> `OOReporter.setRequestReward` reads `Request.reward` from a hardcoded ABI word after a raw `staticcall`. A future request-layout change could silently make it read another field and calculate the wrong funding or refund delta.

This PR is built on [#56](https://github.com/UMAprotocol/managed-oracle/pull/56), which introduces the reward-update path reviewed by this finding.

References: [OpenZeppelin audit finding](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues/hardcoded-assembly-offset-in-setrequestreward-can-misread-the-reward-if-the-request-layout-changes-242dee42) · [FRO-112](https://linear.app/uma/issue/FRO-112/oz-retainer-07l-05-avoid-hardcoded-assembly-if-possible) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Add a guarded `getRequestReward` scalar view to `OptimisticOracleV2`.
- Replace the reporter's raw `staticcall` and hardcoded assembly offset with a typed scalar call.
- Preserve reward accounting, access control, lifecycle behavior, storage layout, and the existing full-request getter.
- Add focused production-getter coverage to the existing requester reward-update test.

## Validation

- `forge test --match-contract 'ManagedOptimisticOracleV2Test|DeferredPayoutTest'` — 73 tests passed
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 45 tests passed
- `forge build --sizes --use 0.8.30` — `ManagedOptimisticOracleV2` 24,363 B (213 B margin)
- `forge build --sizes` with solc 0.8.34 — `ManagedOptimisticOracleV2` 24,378 B (198 B margin)
- `cd pm-v2-oo-reporter && forge build --sizes --optimize false` — `OOReporter` 24,463 B (113 B margin)
- Compatibility build with #58 and solc 0.8.34 — `ManagedOptimisticOracleV2` 24,528 B (48 B margin)
- `git diff --check`
