### PR TITLE
fix[oz-retainer-07-n-06]: update reward cache before oracle call

### DIFF
--- a/pm-v2-oo-reporter/README.md
+++ b/pm-v2-oo-reporter/README.md
@@ -90,7 +90,8 @@ Any enabled oracle initializer can call `setRequestReward(requestId, newReward)`
 still waiting for a proposal. The caller does not need to be the initializer that created the active request. Increasing
 the reward pulls only the delta from the reporter's reward balance; decreasing it, including setting it to zero, refunds
 the delta to the reporter or credits a deferred payout if the token transfer fails. The reporter updates its cached
-reward only after Managed OO accepts the change, so later automatic re-requests reuse the updated amount.
+reward before calling Managed OO so callbacks observe the new amount. If the oracle rejects the change, the transaction
+reverts the cache update as well; successful changes are reused by later automatic re-requests.
 
 Because enabled initializers can spend the reporter's reward balance, initializer infrastructure should enforce an
 operational maximum reward and the reporter should hold only the working balance needed for requests rather than a

--- a/pm-v2-oo-reporter/src/OOReporter.sol
+++ b/pm-v2-oo-reporter/src/OOReporter.sol
@@ -262,8 +262,8 @@ contract OOReporter is OwnableUpgradeable, UUPSUpgradeable, MulticallUpgradeable
             _prepareReward(currency, oracle, newReward - oldReward);
         }
 
-        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
         request.reward = newReward;
+        oracle.setReward(request.priceIdentifier, request.requestTimestamp, request.requestRules, newReward);
 
         emit RequestRewardUpdated(
             requestId, request.requestTimestamp, msg.sender, address(currency), oldReward, newReward

--- a/pm-v2-oo-reporter/test/OOReporter.t.sol
+++ b/pm-v2-oo-reporter/test/OOReporter.t.sol
@@ -395,6 +395,7 @@ contract OOReporterTest {
 
         vm.prank(address(reporter));
         usdc.approve(address(optimisticOracle), 0);
+        optimisticOracle.expectReporterRewardDuringSetReward(REQUEST_ID, REREQUEST_REWARD);
 
         vm.expectEmit(address(reporter));
         emit RequestRewardUpdated(

--- a/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
+++ b/pm-v2-oo-reporter/test/mocks/MockOptimisticOracleV2.sol
@@ -5,6 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {IOptimisticOracleV2} from "src/interfaces/IOptimisticOracleV2.sol";
 import {IOptimisticRequester} from "src/interfaces/IOptimisticRequester.sol";
+import {IOOReporter} from "src/interfaces/IOOReporter.sol";
 
 contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     struct MockRequest {
@@ -32,6 +33,8 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
     mapping(IERC20 currency => mapping(address deferredRecipient => uint256 amount)) public deferredPayouts;
     uint256 public minimumDisputeWindow = 5 minutes;
     bool public deferNextDisputeRefund;
+    bytes32 private expectedRewardRequestId;
+    uint256 private expectedReporterReward;
 
     function getMockRequest(bytes32 key) external view returns (MockRequest memory) {
         return requests[key];
@@ -237,9 +240,22 @@ contract MockOptimisticOracleV2 is IOptimisticOracleV2 {
         minimumDisputeWindow = newMinimumDisputeWindow;
     }
 
+    function expectReporterRewardDuringSetReward(bytes32 requestId, uint256 reward) external {
+        expectedRewardRequestId = requestId;
+        expectedReporterReward = reward;
+    }
+
     function _setReward(MockRequest storage request, address requester, uint256 newReward) private {
         require(request.requested, "not requested");
         require(!request.proposed, "already proposed");
+
+        if (expectedRewardRequestId != bytes32(0)) {
+            require(
+                IOOReporter(requester).getRequest(expectedRewardRequestId).reward == expectedReporterReward,
+                "reporter reward not updated"
+            );
+            expectedRewardRequestId = bytes32(0);
+        }
 
         uint256 oldReward = request.reward;
         request.reward = newReward;


### PR DESCRIPTION
## Audit finding

OpenZeppelin Retainer 07 identified the following issue:

> ### N-06 — Reward Cache in `setRequestReward` Is Updated After External Oracle Call
>
> - Severity: Notes
> - Status: Open
>
> `OOReporter.setRequestReward` updates its cached reward only after calling `oracle.setReward`. A callback during that external call can therefore observe stale reporter state, making checks-effects-interactions safety depend on the oracle's lock and the reward token's behavior.

This PR is stacked on [#63](https://github.com/UMAprotocol/managed-oracle/pull/63), which replaces the full-request assembly decode used by the same reward-update path.

References: [OpenZeppelin audit finding](https://audits.openzeppelin.com/risk-labs/uma-25-retainer-07-oo-reporter-polymarket-v2/issues/reward-cache-in-setrequestreward-is-updated-after-external-oracle-call-dd10e8dd) · [FRO-114](https://linear.app/uma/issue/FRO-114/oz-retainer-07n-06-reward-cache-in-setrequestreward-is-updated-after) · [audited scope tag](https://github.com/UMAprotocol/managed-oracle/tree/audit/oz-pm-v2-oo-reporter-retainer-07-scope-head)

## Resolution

- Write the reporter's cached reward before calling `oracle.setReward`, so callbacks observe the new value.
- Retain Managed OO as the authoritative source for the old reward and preserve delta funding behavior.
- Rely on transaction atomicity to restore the previous cache if the oracle rejects the update.
- Update the reward-flow documentation to describe the CEI ordering and rollback behavior.
- Extend the existing reward-update regression so the mock oracle verifies the cache during the external call.
- Preserve access control, lifecycle behavior, ABI, storage layout, and production runtime size.

## Validation

- Pre-fix regression — fails with `reporter reward not updated`
- `cd pm-v2-oo-reporter && forge test --match-path test/OOReporter.t.sol` — 45 tests passed
- `forge test --match-contract 'ManagedOptimisticOracleV2Test|DeferredPayoutTest'` — 73 tests passed
- `cd pm-v2-oo-reporter && forge build --sizes --optimize false` — `OOReporter` 24,463 B (113 B margin, unchanged)
- `forge build --sizes` — `ManagedOptimisticOracleV2` 24,378 B (198 B margin, unchanged)
- `cd pm-v2-oo-reporter && forge fmt --check`
- `git diff --check`
