### PR TITLE
test: validate Polymarket v2 end-to-end environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains UMA Managed Optimistic Oracle contracts.
 
 - `src/optimistic-oracle-v2/` contains the Managed Optimistic Oracle V2 implementation and interfaces.
 - `pm-v2-oo-reporter/` contains the isolated PM v2 OOReporter Foundry package for prediction market integrations that need a request-oriented Managed OO requester and raw outcome source.
+- `test/polymarket-v2/` contains versioned VNet and Amoy manifests plus the read-only-fork Polymarket v2 end-to-end validation.
 
 ## Foundry
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ extra_output = ["storageLayout"]
 optimizer = true
 optimizer_runs = 1
 via_ir = true
+fs_permissions = [{ access = "read", path = "./test/polymarket-v2" }]
 
 # Fork testing configuration
 [rpc_endpoints]

--- a/test/polymarket-v2/EnvironmentManifest.sol
+++ b/test/polymarket-v2/EnvironmentManifest.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {stdJson} from "forge-std/StdJson.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+struct CoreDeployment {
+    string repository;
+    string artifact;
+    string sourcePath;
+    string sourceBlob;
+    string deploymentRecordRevision;
+    string sourceRevision;
+    string abiRevision;
+    string proxyType;
+    address proxy;
+    address implementation;
+    address proxyAdmin;
+    address upgradeAuthority;
+    uint256 proxyDeploymentBlock;
+    uint256 implementationDeploymentBlock;
+    uint256 implementationActivationBlock;
+    bytes32 proxyCodehash;
+    bytes32 implementationCodehash;
+}
+
+struct ExternalDeployment {
+    string artifact;
+    string deploymentType;
+    address contractAddress;
+    uint256 deploymentBlock;
+    bytes32 codehash;
+}
+
+struct SourceRevisions {
+    string managedOracle;
+    string managedOracleDeploymentTooling;
+    string ooReporterDeploymentTooling;
+    string polymarket;
+    string polymarketDeploymentConfig;
+}
+
+struct EnvironmentRoles {
+    address aggregatorOwner;
+    address moduleOwner;
+    address reporterOwner;
+    address reporterPendingOwner;
+    address managedOracleDefaultAdmin;
+    uint256 managedOracleDefaultAdminDelay;
+    address managedOraclePendingDefaultAdmin;
+    uint256 managedOraclePendingDefaultAdminSchedule;
+    address requesterWhitelistOwner;
+    address defaultProposerWhitelistOwner;
+    address[] requiredAggregatorAdmins;
+    address[] requiredAggregatorOperators;
+    address[] requiredModuleAdmins;
+    address[] requiredModuleOperators;
+    address[] requiredOracleInitializersAndProposers;
+    address[] requiredManagedOracleConfigAdmins;
+    address[] requiredManagedOracleRequestManagers;
+    address[] requiredManagedOracleResolverAdmins;
+    address[] requiredManagedOracleResolvers;
+    address disputerAndArbitratorModule;
+}
+
+struct EnvironmentCapabilities {
+    bool snapshotStateVerified;
+    bool automaticReporterCallback;
+    bool reporterTwoStepOwnership;
+    bool fullLifecycleSimulation;
+}
+
+struct EnvironmentManifest {
+    uint256 schemaVersion;
+    string environment;
+    string purpose;
+    uint256 chainId;
+    string rpcEnvironmentVariable;
+    string explorer;
+    string explorerEnvironmentVariable;
+    uint256 snapshotBlock;
+    string snapshotBlockRpc;
+    bytes32 snapshotBlockHash;
+    SourceRevisions sources;
+    string testAbiBundle;
+    bytes32 testAbiBundleHash;
+    CoreDeployment aggregator;
+    CoreDeployment reporterModule;
+    CoreDeployment reporter;
+    CoreDeployment managedOracle;
+    CoreDeployment binaryModule;
+    ExternalDeployment rewardCurrency;
+    ExternalDeployment requesterWhitelist;
+    ExternalDeployment defaultProposerWhitelist;
+    EnvironmentRoles roles;
+    EnvironmentCapabilities capabilities;
+    string[] knownBlockers;
+}
+
+library EnvironmentManifestLib {
+    using stdJson for string;
+
+    Vm private constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function load(string memory relativePath) internal view returns (EnvironmentManifest memory manifest) {
+        string memory json = raw(relativePath);
+
+        manifest.schemaVersion = json.readUint(".schemaVersion");
+        manifest.environment = json.readString(".environment");
+        manifest.purpose = json.readString(".purpose");
+        manifest.chainId = json.readUint(".chainId");
+        manifest.rpcEnvironmentVariable = json.readString(".rpcEnvironmentVariable");
+        manifest.explorer = json.readString(".explorer.name");
+        manifest.explorerEnvironmentVariable = json.readString(".explorer.baseUrlEnvironmentVariable");
+        manifest.snapshotBlock = json.readUint(".snapshot.blockNumber");
+        manifest.snapshotBlockRpc = json.readString(".snapshot.rpcBlockNumber");
+        manifest.snapshotBlockHash = json.readBytes32(".snapshot.blockHash");
+
+        manifest.sources = SourceRevisions({
+            managedOracle: json.readString(".sources.managedOracle"),
+            managedOracleDeploymentTooling: json.readString(".sources.managedOracleDeploymentTooling"),
+            ooReporterDeploymentTooling: json.readString(".sources.ooReporterDeploymentTooling"),
+            polymarket: json.readString(".sources.polymarket"),
+            polymarketDeploymentConfig: json.readString(".sources.polymarketDeploymentConfig")
+        });
+        manifest.testAbiBundle = json.readString(".testAbiBundle.path");
+        manifest.testAbiBundleHash = json.readBytes32(".testAbiBundle.keccak256");
+
+        manifest.aggregator = _deployment(json, ".contracts.aggregator");
+        manifest.reporterModule = _deployment(json, ".contracts.reporterModule");
+        manifest.reporter = _deployment(json, ".contracts.reporter");
+        manifest.managedOracle = _deployment(json, ".contracts.managedOracle");
+        manifest.binaryModule = _deployment(json, ".contracts.binaryModule");
+        manifest.rewardCurrency = _externalDeployment(json, ".contracts.rewardCurrency");
+        manifest.requesterWhitelist = _externalDeployment(json, ".contracts.requesterWhitelist");
+        manifest.defaultProposerWhitelist = _externalDeployment(json, ".contracts.defaultProposerWhitelist");
+
+        manifest.roles = EnvironmentRoles({
+            aggregatorOwner: json.readAddress(".roles.aggregatorOwner"),
+            moduleOwner: json.readAddress(".roles.moduleOwner"),
+            reporterOwner: json.readAddress(".roles.reporterOwner"),
+            reporterPendingOwner: json.readAddress(".roles.reporterPendingOwner"),
+            managedOracleDefaultAdmin: json.readAddress(".roles.managedOracleDefaultAdmin"),
+            managedOracleDefaultAdminDelay: json.readUint(".roles.managedOracleDefaultAdminDelay"),
+            managedOraclePendingDefaultAdmin: json.readAddress(".roles.managedOraclePendingDefaultAdmin"),
+            managedOraclePendingDefaultAdminSchedule: json.readUint(".roles.managedOraclePendingDefaultAdminSchedule"),
+            requesterWhitelistOwner: json.readAddress(".roles.requesterWhitelistOwner"),
+            defaultProposerWhitelistOwner: json.readAddress(".roles.defaultProposerWhitelistOwner"),
+            requiredAggregatorAdmins: json.readAddressArray(".roles.requiredAggregatorAdmins"),
+            requiredAggregatorOperators: json.readAddressArray(".roles.requiredAggregatorOperators"),
+            requiredModuleAdmins: json.readAddressArray(".roles.requiredModuleAdmins"),
+            requiredModuleOperators: json.readAddressArray(".roles.requiredModuleOperators"),
+            requiredOracleInitializersAndProposers: json.readAddressArray(
+                ".roles.requiredOracleInitializersAndProposers"
+            ),
+            requiredManagedOracleConfigAdmins: json.readAddressArray(".roles.requiredManagedOracleConfigAdmins"),
+            requiredManagedOracleRequestManagers: json.readAddressArray(".roles.requiredManagedOracleRequestManagers"),
+            requiredManagedOracleResolverAdmins: json.readAddressArray(".roles.requiredManagedOracleResolverAdmins"),
+            requiredManagedOracleResolvers: json.readAddressArray(".roles.requiredManagedOracleResolvers"),
+            disputerAndArbitratorModule: json.readAddress(".roles.disputerAndArbitratorModule")
+        });
+
+        manifest.capabilities = EnvironmentCapabilities({
+            snapshotStateVerified: json.readBool(".capabilities.snapshotStateVerified"),
+            automaticReporterCallback: json.readBool(".capabilities.automaticReporterCallback"),
+            reporterTwoStepOwnership: json.readBool(".capabilities.reporterTwoStepOwnership"),
+            fullLifecycleSimulation: json.readBool(".capabilities.fullLifecycleSimulation")
+        });
+        manifest.knownBlockers = json.readStringArray(".knownBlockers");
+    }
+
+    function raw(string memory relativePath) internal view returns (string memory) {
+        return VM.readFile(string.concat(VM.projectRoot(), "/", relativePath));
+    }
+
+    function _deployment(string memory json, string memory key)
+        private
+        pure
+        returns (CoreDeployment memory deployment)
+    {
+        deployment.repository = json.readString(string.concat(key, ".repository"));
+        deployment.artifact = json.readString(string.concat(key, ".artifact"));
+        deployment.sourcePath = json.readString(string.concat(key, ".sourcePath"));
+        deployment.sourceBlob = json.readString(string.concat(key, ".sourceBlob"));
+        deployment.deploymentRecordRevision = json.readString(string.concat(key, ".deploymentRecordRevision"));
+        deployment.sourceRevision = json.readString(string.concat(key, ".sourceRevision"));
+        deployment.abiRevision = json.readString(string.concat(key, ".abiRevision"));
+        deployment.proxyType = json.readString(string.concat(key, ".proxyType"));
+        deployment.proxy = json.readAddress(string.concat(key, ".proxy"));
+        deployment.implementation = json.readAddress(string.concat(key, ".implementation"));
+        deployment.proxyAdmin = json.readAddress(string.concat(key, ".proxyAdmin"));
+        deployment.upgradeAuthority = json.readAddress(string.concat(key, ".upgradeAuthority"));
+        deployment.proxyDeploymentBlock = json.readUint(string.concat(key, ".proxyDeploymentBlock"));
+        deployment.implementationDeploymentBlock = json.readUint(string.concat(key, ".implementationDeploymentBlock"));
+        deployment.implementationActivationBlock = json.readUint(string.concat(key, ".implementationActivationBlock"));
+        deployment.proxyCodehash = json.readBytes32(string.concat(key, ".proxyCodehash"));
+        deployment.implementationCodehash = json.readBytes32(string.concat(key, ".implementationCodehash"));
+    }
+
+    function _externalDeployment(string memory json, string memory key)
+        private
+        pure
+        returns (ExternalDeployment memory deployment)
+    {
+        deployment.artifact = json.readString(string.concat(key, ".artifact"));
+        deployment.deploymentType = json.readString(string.concat(key, ".deploymentType"));
+        deployment.contractAddress = json.readAddress(string.concat(key, ".address"));
+        deployment.deploymentBlock = json.readUint(string.concat(key, ".deploymentBlock"));
+        deployment.codehash = json.readBytes32(string.concat(key, ".codehash"));
+    }
+}

--- a/test/polymarket-v2/EnvironmentManifest.sol
+++ b/test/polymarket-v2/EnvironmentManifest.sol
@@ -150,9 +150,7 @@ library EnvironmentManifestLib {
             requiredAggregatorOperators: json.readAddressArray(".roles.requiredAggregatorOperators"),
             requiredModuleAdmins: json.readAddressArray(".roles.requiredModuleAdmins"),
             requiredModuleOperators: json.readAddressArray(".roles.requiredModuleOperators"),
-            requiredOracleInitializersAndProposers: json.readAddressArray(
-                ".roles.requiredOracleInitializersAndProposers"
-            ),
+            requiredOracleInitializersAndProposers: json.readAddressArray(".roles.requiredOracleInitializersAndProposers"),
             requiredManagedOracleConfigAdmins: json.readAddressArray(".roles.requiredManagedOracleConfigAdmins"),
             requiredManagedOracleRequestManagers: json.readAddressArray(".roles.requiredManagedOracleRequestManagers"),
             requiredManagedOracleResolverAdmins: json.readAddressArray(".roles.requiredManagedOracleResolverAdmins"),

--- a/test/polymarket-v2/PolymarketV2EndToEnd.Fork.t.sol
+++ b/test/polymarket-v2/PolymarketV2EndToEnd.Fork.t.sol
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {EnvironmentManifest, EnvironmentManifestLib} from "./EnvironmentManifest.sol";
+import {
+    IBinaryModuleLike,
+    IManagedOptimisticOracleLike,
+    IOOReporterModuleLike,
+    IPolymarketAggregator,
+    IPolymarketOOReporterLike
+} from "./PolymarketV2Interfaces.sol";
+
+contract PolymarketV2EndToEndForkTest is Test {
+    string private constant MANIFEST_PATH = "test/polymarket-v2/environments/vnet.json";
+    string private constant FIXTURE_DOMAIN = "uma-fro-111-polymarket-v2-e2e-binary-v1";
+    bytes32 private constant EXPECTED_REQUEST_ID = 0x018804eed8e0a0aaae200582e434c0b4f5000000000000000000000000000000;
+    bytes32 private constant YES_OR_NO_QUERY = bytes32("YES_OR_NO_QUERY");
+    int256 private constant YES_PRICE = 1e18;
+    uint256 private constant RESULT_DENOMINATOR = 1_000_000;
+    uint256 private constant EXPECTED_TOTAL_BOND = 500_000_000;
+    uint64 private constant ORACLE_LIVENESS = 5 minutes;
+    uint32 private constant AGGREGATOR_LIVENESS = 1 hours;
+    bytes4 private constant UNAUTHORIZED_SELECTOR = bytes4(keccak256("Unauthorized()"));
+
+    bytes32 private constant REQUEST_PRICE_EVENT =
+        keccak256("RequestPrice(address,bytes32,uint256,bytes,address,uint256,uint256)");
+    bytes32 private constant PROPOSE_PRICE_EVENT =
+        keccak256("ProposePrice(address,address,bytes32,uint256,bytes,int256,uint256,address)");
+    bytes32 private constant SETTLE_EVENT =
+        keccak256("Settle(address,address,address,bytes32,uint256,bytes,int256,uint256)");
+    bytes32 private constant REQUEST_REGISTERED_EVENT =
+        keccak256("RequestRegistered(bytes32,address,bytes32,bytes,uint64,uint64)");
+    bytes32 private constant REQUEST_INITIALIZED_EVENT =
+        keccak256("RequestInitialized(bytes32,uint256,address,bytes32,bytes,address,uint256,uint256,uint64,uint256)");
+    bytes32 private constant REQUEST_RESOLVED_EVENT = keccak256("RequestResolved(bytes32,uint256,int256)");
+    bytes32 private constant REPORT_CALLBACK_SUCCEEDED_EVENT = keccak256("ReportCallbackSucceeded(bytes32,address)");
+    bytes32 private constant OO_REPORTER_REQUEST_CREATED_EVENT = keccak256("OOReporterRequestCreated(bytes32,bytes32)");
+    bytes32 private constant OO_REPORTER_RESULT_REPORTED_EVENT =
+        keccak256("OOReporterResultReported(bytes32,int256,bytes32)");
+    bytes32 private constant AGGREGATOR_REQUEST_INITIALIZED_EVENT =
+        keccak256("RequestInitialized(bytes29,address,uint256,uint256,uint16,uint8,address,uint32,address)");
+    bytes32 private constant AGGREGATOR_RESULT_REPORTED_EVENT =
+        keccak256("ResultReported(bytes32,address,bytes32,uint256)");
+    bytes32 private constant OUTCOME_PROPOSED_EVENT = keccak256("OutcomeProposed(bytes32,bytes32,uint256[])");
+    bytes32 private constant AGGREGATOR_REQUEST_RESOLVED_EVENT = keccak256("RequestResolved(bytes32,bytes32,address)");
+
+    EnvironmentManifest private manifest;
+    bool private forkEnabled;
+
+    function setUp() public {
+        manifest = EnvironmentManifestLib.load(MANIFEST_PATH);
+        string memory rpcUrl = vm.envOr(manifest.rpcEnvironmentVariable, string(""));
+        if (bytes(rpcUrl).length == 0) return;
+
+        _assertSnapshotHash(rpcUrl);
+        vm.createSelectFork(rpcUrl, manifest.snapshotBlock);
+        forkEnabled = true;
+    }
+
+    function test_happyPathRunsEntirelyInsideLocalFork() public {
+        if (!_requireFork()) return;
+
+        bytes32 requestId = _requestId();
+        bytes memory requestRules = _requestRules();
+        IPolymarketAggregator aggregator = IPolymarketAggregator(manifest.aggregator.proxy);
+        IOOReporterModuleLike reporterModule = IOOReporterModuleLike(manifest.reporterModule.proxy);
+        IPolymarketOOReporterLike reporter = IPolymarketOOReporterLike(manifest.reporter.proxy);
+        IManagedOptimisticOracleLike managedOracle = IManagedOptimisticOracleLike(manifest.managedOracle.proxy);
+
+        assertEq(requestId, EXPECTED_REQUEST_ID, "fixture ID scheme changed");
+        assertEq(block.number, manifest.snapshotBlock);
+        assertFalse(reporterModule.requestInitialized(bytes31(requestId)), "fixture already registered");
+        (IPolymarketAggregator.ResolutionStatus initialStatus,,,) = aggregator.getRequestState(requestId);
+        assertEq(uint8(initialStatus), uint8(IPolymarketAggregator.ResolutionStatus.None));
+        assertEq(IBinaryModuleLike(manifest.binaryModule.proxy).getResult(bytes31(requestId)).length, 0);
+
+        vm.recordLogs();
+
+        vm.prank(manifest.roles.requiredAggregatorOperators[0]);
+        aggregator.initializeRequest(_initParams(requestId, requestRules));
+
+        IPolymarketOOReporterLike.RequestData memory reporterRequest = reporter.getRequest(requestId);
+        assertTrue(reporterModule.requestInitialized(bytes31(requestId)));
+        assertTrue(reporterRequest.registered);
+        assertFalse(reporterRequest.initialized);
+        assertEq(reporterRequest.requester, address(reporterModule));
+        assertEq(reporterRequest.priceIdentifier, YES_OR_NO_QUERY);
+        assertEq(reporterRequest.requestRules, requestRules);
+        assertEq(reporterRequest.minimumLiveness, ORACLE_LIVENESS);
+        assertEq(reporterRequest.maximumLiveness, 2 hours);
+        assertTrue(aggregator.isReporterModule(bytes29(requestId), address(reporterModule)));
+        assertTrue(aggregator.isDisputerModule(bytes29(requestId), manifest.roles.disputerAndArbitratorModule));
+        (uint8 marketType, uint16 outcomeCount) = aggregator.getRequestShape(requestId);
+        assertEq(marketType, uint8(IPolymarketAggregator.MarketType.BINARY));
+        assertEq(outcomeCount, 1);
+
+        vm.prank(manifest.roles.requiredOracleInitializersAndProposers[0]);
+        reporter.initializeRequest(requestId, 0, 0, ORACLE_LIVENESS);
+
+        reporterRequest = reporter.getRequest(requestId);
+        assertTrue(reporterRequest.initialized);
+        assertEq(reporterRequest.oracleInitializer, manifest.roles.requiredOracleInitializersAndProposers[0]);
+        assertEq(reporterRequest.liveness, ORACLE_LIVENESS);
+
+        IManagedOptimisticOracleLike.Request memory oracleRequest = managedOracle.getRequest(
+            address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules
+        );
+        assertTrue(oracleRequest.requestSettings.eventBased);
+        assertTrue(oracleRequest.requestSettings.callbackOnPriceSettled);
+        assertEq(oracleRequest.requestSettings.customLiveness, ORACLE_LIVENESS);
+
+        uint256 totalBond = oracleRequest.requestSettings.bond + oracleRequest.finalFee;
+        assertEq(totalBond, EXPECTED_TOTAL_BOND);
+        address proposer = manifest.roles.requiredOracleInitializersAndProposers[0];
+        deal(address(oracleRequest.currency), proposer, totalBond, true);
+
+        vm.startPrank(proposer);
+        oracleRequest.currency.approve(address(managedOracle), totalBond);
+        uint256 postedBond = managedOracle.proposePriceFor(
+            proposer, address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules, YES_PRICE
+        );
+        vm.stopPrank();
+        assertEq(postedBond, totalBond);
+
+        oracleRequest = managedOracle.getRequest(
+            address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules
+        );
+        assertEq(oracleRequest.proposer, proposer);
+        assertEq(oracleRequest.proposedPrice, YES_PRICE);
+        assertGt(oracleRequest.expirationTime, block.timestamp);
+        uint256 proposalExpiration = oracleRequest.expirationTime;
+
+        vm.warp(oracleRequest.expirationTime);
+        vm.prank(manifest.roles.requiredManagedOracleResolvers[0]);
+        uint256 payout =
+            managedOracle.settle(address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules);
+        assertEq(payout, totalBond);
+
+        assertTrue(reporter.isRequestResolved(requestId));
+        assertEq(reporter.getRequestResolution(requestId), YES_PRICE);
+
+        uint256[] memory expectedProposal = new uint256[](1);
+        expectedProposal[0] = RESULT_DENOMINATOR;
+        bytes32 expectedProposalHash = keccak256(abi.encode(expectedProposal));
+
+        (IPolymarketAggregator.ResolutionStatus proposedStatus, bytes32 proposedResultHash, uint256 disputeWindowEnd,) =
+            aggregator.getRequestState(requestId);
+        assertEq(uint8(proposedStatus), uint8(IPolymarketAggregator.ResolutionStatus.Active));
+        assertEq(proposedResultHash, expectedProposalHash);
+        assertGt(disputeWindowEnd, block.timestamp);
+
+        vm.warp(disputeWindowEnd);
+        reporterModule.finalize(requestId);
+
+        (IPolymarketAggregator.ResolutionStatus finalStatus, bytes32 finalResultHash,,) =
+            aggregator.getRequestState(requestId);
+        assertEq(uint8(finalStatus), uint8(IPolymarketAggregator.ResolutionStatus.Resolved));
+        assertEq(finalResultHash, expectedProposalHash);
+
+        uint256[] memory binaryResult = IBinaryModuleLike(manifest.binaryModule.proxy).getResult(bytes31(requestId));
+        assertEq(binaryResult.length, 2);
+        assertEq(binaryResult[0], RESULT_DENOMINATOR);
+        assertEq(binaryResult[1], 0);
+
+        _assertLifecycleEvents(
+            vm.getRecordedLogs(),
+            requestId,
+            requestRules,
+            reporterRequest,
+            oracleRequest.finalFee,
+            proposalExpiration,
+            totalBond,
+            expectedProposal,
+            expectedProposalHash
+        );
+    }
+
+    function test_unauthorizedAccountCannotInitializeAggregatorRequest() public {
+        if (!_requireFork()) return;
+
+        vm.expectRevert(UNAUTHORIZED_SELECTOR);
+        vm.prank(address(0xBEEF));
+        IPolymarketAggregator(manifest.aggregator.proxy).initializeRequest(_initParams(_requestId(), _requestRules()));
+    }
+
+    function _initParams(bytes32 requestId, bytes memory requestRules)
+        private
+        view
+        returns (IPolymarketAggregator.InitParams memory params)
+    {
+        IOOReporterModuleLike.RequestRegistration[] memory registrations =
+            new IOOReporterModuleLike.RequestRegistration[](1);
+        registrations[0] = IOOReporterModuleLike.RequestRegistration({
+            requestId: requestId, requestRules: requestRules, minimumLiveness: ORACLE_LIVENESS, maximumLiveness: 2 hours
+        });
+
+        IPolymarketAggregator.ModuleConfig[] memory reporters = new IPolymarketAggregator.ModuleConfig[](1);
+        reporters[0] = IPolymarketAggregator.ModuleConfig({
+            module: manifest.reporterModule.proxy, initData: abi.encode(registrations)
+        });
+
+        IPolymarketAggregator.ModuleConfig[] memory disputers = new IPolymarketAggregator.ModuleConfig[](1);
+        disputers[0] = IPolymarketAggregator.ModuleConfig({
+            module: manifest.roles.disputerAndArbitratorModule, initData: bytes("")
+        });
+
+        params = IPolymarketAggregator.InitParams({
+            eventId: bytes29(requestId),
+            marketType: IPolymarketAggregator.MarketType.BINARY,
+            targetContract: manifest.binaryModule.proxy,
+            resultLength: 1,
+            reporterModules: reporters,
+            reporterThreshold: 1,
+            disputerModules: disputers,
+            disputerThreshold: 1,
+            arbitratorModule: manifest.roles.disputerAndArbitratorModule,
+            arbitratorInitData: bytes(""),
+            livenessWindow: AGGREGATOR_LIVENESS,
+            finalizer: manifest.reporterModule.proxy
+        });
+    }
+
+    function _requestId() private pure returns (bytes32) {
+        bytes32 baseHash = keccak256(abi.encode(uint256(1), bytes(FIXTURE_DOMAIN)));
+        uint256 low128 = uint256(uint128(uint256(baseHash)));
+        return bytes32((uint256(1) << 248) | (low128 << 120));
+    }
+
+    function _requestRules() private pure returns (bytes memory) {
+        return bytes("FRO-111 deterministic local-fork lifecycle: resolve YES for the fixture scenario.");
+    }
+
+    function _requireFork() private returns (bool) {
+        if (forkEnabled) return true;
+        vm.skip(true, string.concat("set ", manifest.rpcEnvironmentVariable, " to run this local fork simulation"));
+        return false;
+    }
+
+    function _assertLifecycleEvents(
+        Vm.Log[] memory logs,
+        bytes32 requestId,
+        bytes memory requestRules,
+        IPolymarketOOReporterLike.RequestData memory reporterRequest,
+        uint256 finalFee,
+        uint256 proposalExpiration,
+        uint256 totalBond,
+        uint256[] memory expectedProposal,
+        bytes32 expectedProposalHash
+    ) private view {
+        _assertManagedOracleEvents(logs, requestRules, reporterRequest, finalFee, proposalExpiration, totalBond);
+        _assertReporterEvents(logs, requestId, requestRules, reporterRequest);
+        _assertPolymarketEvents(logs, requestId, expectedProposal, expectedProposalHash);
+    }
+
+    function _assertManagedOracleEvents(
+        Vm.Log[] memory logs,
+        bytes memory requestRules,
+        IPolymarketOOReporterLike.RequestData memory reporterRequest,
+        uint256 finalFee,
+        uint256 proposalExpiration,
+        uint256 totalBond
+    ) private view {
+        address proposer = manifest.roles.requiredOracleInitializersAndProposers[0];
+
+        {
+            Vm.Log memory requestPrice =
+                _event(logs, manifest.managedOracle.proxy, REQUEST_PRICE_EVENT, bytes32(0), "Managed OO RequestPrice");
+            assertEq(_topicAddress(requestPrice.topics[1]), manifest.reporter.proxy);
+            (
+                bytes32 identifier,
+                uint256 timestamp,
+                bytes memory ancillaryData,
+                address currency,
+                uint256 reward,
+                uint256 emittedFinalFee
+            ) = abi.decode(requestPrice.data, (bytes32, uint256, bytes, address, uint256, uint256));
+            assertEq(identifier, YES_OR_NO_QUERY);
+            assertEq(timestamp, reporterRequest.requestTimestamp);
+            assertEq(ancillaryData, requestRules);
+            assertEq(currency, manifest.rewardCurrency.contractAddress);
+            assertEq(reward, reporterRequest.reward);
+            assertEq(emittedFinalFee, finalFee);
+        }
+
+        {
+            Vm.Log memory proposePrice =
+                _event(logs, manifest.managedOracle.proxy, PROPOSE_PRICE_EVENT, bytes32(0), "Managed OO ProposePrice");
+            assertEq(_topicAddress(proposePrice.topics[1]), manifest.reporter.proxy);
+            assertEq(_topicAddress(proposePrice.topics[2]), proposer);
+            (
+                bytes32 identifier,
+                uint256 timestamp,
+                bytes memory ancillaryData,
+                int256 proposedPrice,
+                uint256 expirationTimestamp,
+                address currency
+            ) = abi.decode(proposePrice.data, (bytes32, uint256, bytes, int256, uint256, address));
+            assertEq(identifier, YES_OR_NO_QUERY);
+            assertEq(timestamp, reporterRequest.requestTimestamp);
+            assertEq(ancillaryData, requestRules);
+            assertEq(proposedPrice, YES_PRICE);
+            assertEq(expirationTimestamp, proposalExpiration);
+            assertEq(currency, manifest.rewardCurrency.contractAddress);
+        }
+
+        {
+            Vm.Log memory settle =
+                _event(logs, manifest.managedOracle.proxy, SETTLE_EVENT, bytes32(0), "Managed OO Settle");
+            assertEq(_topicAddress(settle.topics[1]), manifest.reporter.proxy);
+            assertEq(_topicAddress(settle.topics[2]), proposer);
+            assertEq(_topicAddress(settle.topics[3]), address(0));
+            (bytes32 identifier, uint256 timestamp, bytes memory ancillaryData, int256 price, uint256 payout) =
+                abi.decode(settle.data, (bytes32, uint256, bytes, int256, uint256));
+            assertEq(identifier, YES_OR_NO_QUERY);
+            assertEq(timestamp, reporterRequest.requestTimestamp);
+            assertEq(ancillaryData, requestRules);
+            assertEq(price, YES_PRICE);
+            assertEq(payout, totalBond);
+        }
+    }
+
+    function _assertReporterEvents(
+        Vm.Log[] memory logs,
+        bytes32 requestId,
+        bytes memory requestRules,
+        IPolymarketOOReporterLike.RequestData memory reporterRequest
+    ) private view {
+        {
+            Vm.Log memory registered = _event(
+                logs, manifest.reporter.proxy, REQUEST_REGISTERED_EVENT, requestId, "reporter RequestRegistered"
+            );
+            assertEq(_topicAddress(registered.topics[2]), manifest.reporterModule.proxy);
+            assertEq(registered.topics[3], YES_OR_NO_QUERY);
+            (bytes memory rules, uint64 minimumLiveness, uint64 maximumLiveness) =
+                abi.decode(registered.data, (bytes, uint64, uint64));
+            assertEq(rules, requestRules);
+            assertEq(minimumLiveness, ORACLE_LIVENESS);
+            assertEq(maximumLiveness, 2 hours);
+        }
+
+        {
+            Vm.Log memory initialized = _event(
+                logs, manifest.reporter.proxy, REQUEST_INITIALIZED_EVENT, requestId, "reporter RequestInitialized"
+            );
+            assertEq(uint256(initialized.topics[2]), reporterRequest.requestTimestamp);
+            assertEq(_topicAddress(initialized.topics[3]), manifest.roles.requiredOracleInitializersAndProposers[0]);
+            (
+                bytes32 identifier,
+                bytes memory rules,
+                address currency,
+                uint256 reward,
+                uint256 proposalBond,
+                uint64 liveness,
+                uint256 manualRerequestsRemaining
+            ) = abi.decode(initialized.data, (bytes32, bytes, address, uint256, uint256, uint64, uint256));
+            assertEq(identifier, YES_OR_NO_QUERY);
+            assertEq(rules, requestRules);
+            assertEq(currency, manifest.rewardCurrency.contractAddress);
+            assertEq(reward, reporterRequest.reward);
+            assertEq(proposalBond, reporterRequest.proposalBond);
+            assertEq(liveness, ORACLE_LIVENESS);
+            assertEq(manualRerequestsRemaining, reporterRequest.manualRerequestsRemaining);
+        }
+
+        {
+            Vm.Log memory resolved =
+                _event(logs, manifest.reporter.proxy, REQUEST_RESOLVED_EVENT, requestId, "reporter RequestResolved");
+            assertEq(uint256(resolved.topics[2]), reporterRequest.requestTimestamp);
+            assertEq(abi.decode(resolved.data, (int256)), YES_PRICE);
+        }
+
+        Vm.Log memory callback = _event(
+            logs,
+            manifest.reporter.proxy,
+            REPORT_CALLBACK_SUCCEEDED_EVENT,
+            requestId,
+            "reporter ReportCallbackSucceeded"
+        );
+        assertEq(_topicAddress(callback.topics[2]), manifest.reporterModule.proxy);
+    }
+
+    function _assertPolymarketEvents(
+        Vm.Log[] memory logs,
+        bytes32 requestId,
+        uint256[] memory expectedProposal,
+        bytes32 expectedProposalHash
+    ) private view {
+        {
+            Vm.Log memory requestCreated = _event(
+                logs,
+                manifest.reporterModule.proxy,
+                OO_REPORTER_REQUEST_CREATED_EVENT,
+                requestId,
+                "module OOReporterRequestCreated"
+            );
+            assertEq(abi.decode(requestCreated.data, (bytes32)), YES_OR_NO_QUERY);
+        }
+
+        {
+            Vm.Log memory initialized = _event(
+                logs,
+                manifest.aggregator.proxy,
+                AGGREGATOR_REQUEST_INITIALIZED_EVENT,
+                bytes32(bytes29(requestId)),
+                "aggregator RequestInitialized"
+            );
+            (
+                address targetContract,
+                uint256 reporterThreshold,
+                uint256 disputerThreshold,
+                uint16 resultLength,
+                uint8 marketType,
+                address arbitratorModule,
+                uint32 livenessWindow,
+                address finalizer
+            ) = abi.decode(initialized.data, (address, uint256, uint256, uint16, uint8, address, uint32, address));
+            assertEq(targetContract, manifest.binaryModule.proxy);
+            assertEq(reporterThreshold, 1);
+            assertEq(disputerThreshold, 1);
+            assertEq(resultLength, 1);
+            assertEq(marketType, uint8(IPolymarketAggregator.MarketType.BINARY));
+            assertEq(arbitratorModule, manifest.roles.disputerAndArbitratorModule);
+            assertEq(livenessWindow, AGGREGATOR_LIVENESS);
+            assertEq(finalizer, manifest.reporterModule.proxy);
+        }
+
+        {
+            Vm.Log memory reported = _event(
+                logs,
+                manifest.reporterModule.proxy,
+                OO_REPORTER_RESULT_REPORTED_EVENT,
+                requestId,
+                "module OOReporterResultReported"
+            );
+            (int256 price, bytes32 resultHash) = abi.decode(reported.data, (int256, bytes32));
+            assertEq(price, YES_PRICE);
+            assertEq(resultHash, expectedProposalHash);
+        }
+
+        {
+            Vm.Log memory resultReported = _event(
+                logs,
+                manifest.aggregator.proxy,
+                AGGREGATOR_RESULT_REPORTED_EVENT,
+                requestId,
+                "aggregator ResultReported"
+            );
+            assertEq(_topicAddress(resultReported.topics[2]), manifest.reporterModule.proxy);
+            (bytes32 resultHash, uint256 votes) = abi.decode(resultReported.data, (bytes32, uint256));
+            assertEq(resultHash, expectedProposalHash);
+            assertEq(votes, 1);
+        }
+
+        {
+            Vm.Log memory proposed = _event(
+                logs, manifest.aggregator.proxy, OUTCOME_PROPOSED_EVENT, requestId, "aggregator OutcomeProposed"
+            );
+            (bytes32 resultHash, uint256[] memory result) = abi.decode(proposed.data, (bytes32, uint256[]));
+            assertEq(resultHash, expectedProposalHash);
+            assertEq(result, expectedProposal);
+        }
+
+        {
+            Vm.Log memory resolved = _event(
+                logs,
+                manifest.aggregator.proxy,
+                AGGREGATOR_REQUEST_RESOLVED_EVENT,
+                requestId,
+                "aggregator RequestResolved"
+            );
+            assertEq(_topicAddress(resolved.topics[2]), manifest.aggregator.proxy);
+            assertEq(abi.decode(resolved.data, (bytes32)), expectedProposalHash);
+        }
+    }
+
+    function _assertSnapshotHash(string memory rpcUrl) private {
+        vm.createSelectFork(rpcUrl, manifest.snapshotBlock + 1);
+        assertEq(blockhash(manifest.snapshotBlock), manifest.snapshotBlockHash, "snapshot hash mismatch");
+    }
+
+    function _event(
+        Vm.Log[] memory logs,
+        address emitter,
+        bytes32 signature,
+        bytes32 indexedRequestId,
+        string memory label
+    ) private pure returns (Vm.Log memory) {
+        for (uint256 i; i < logs.length; ++i) {
+            if (logs[i].emitter != emitter || logs[i].topics.length == 0 || logs[i].topics[0] != signature) continue;
+            if (indexedRequestId != bytes32(0)) {
+                if (logs[i].topics.length < 2 || logs[i].topics[1] != indexedRequestId) continue;
+            }
+            return logs[i];
+        }
+        revert(string.concat("missing event: ", label));
+    }
+
+    function _topicAddress(bytes32 topic) private pure returns (address) {
+        return address(uint160(uint256(topic)));
+    }
+}

--- a/test/polymarket-v2/PolymarketV2EndToEnd.Fork.t.sol
+++ b/test/polymarket-v2/PolymarketV2EndToEnd.Fork.t.sol
@@ -106,9 +106,8 @@ contract PolymarketV2EndToEndForkTest is Test {
         assertEq(reporterRequest.oracleInitializer, manifest.roles.requiredOracleInitializersAndProposers[0]);
         assertEq(reporterRequest.liveness, ORACLE_LIVENESS);
 
-        IManagedOptimisticOracleLike.Request memory oracleRequest = managedOracle.getRequest(
-            address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules
-        );
+        IManagedOptimisticOracleLike.Request memory oracleRequest =
+            managedOracle.getRequest(address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules);
         assertTrue(oracleRequest.requestSettings.eventBased);
         assertTrue(oracleRequest.requestSettings.callbackOnPriceSettled);
         assertEq(oracleRequest.requestSettings.customLiveness, ORACLE_LIVENESS);
@@ -126,9 +125,8 @@ contract PolymarketV2EndToEndForkTest is Test {
         vm.stopPrank();
         assertEq(postedBond, totalBond);
 
-        oracleRequest = managedOracle.getRequest(
-            address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules
-        );
+        oracleRequest =
+            managedOracle.getRequest(address(reporter), YES_OR_NO_QUERY, reporterRequest.requestTimestamp, requestRules);
         assertEq(oracleRequest.proposer, proposer);
         assertEq(oracleRequest.proposedPrice, YES_PRICE);
         assertGt(oracleRequest.expirationTime, block.timestamp);
@@ -195,17 +193,22 @@ contract PolymarketV2EndToEndForkTest is Test {
         IOOReporterModuleLike.RequestRegistration[] memory registrations =
             new IOOReporterModuleLike.RequestRegistration[](1);
         registrations[0] = IOOReporterModuleLike.RequestRegistration({
-            requestId: requestId, requestRules: requestRules, minimumLiveness: ORACLE_LIVENESS, maximumLiveness: 2 hours
+            requestId: requestId,
+            requestRules: requestRules,
+            minimumLiveness: ORACLE_LIVENESS,
+            maximumLiveness: 2 hours
         });
 
         IPolymarketAggregator.ModuleConfig[] memory reporters = new IPolymarketAggregator.ModuleConfig[](1);
         reporters[0] = IPolymarketAggregator.ModuleConfig({
-            module: manifest.reporterModule.proxy, initData: abi.encode(registrations)
+            module: manifest.reporterModule.proxy,
+            initData: abi.encode(registrations)
         });
 
         IPolymarketAggregator.ModuleConfig[] memory disputers = new IPolymarketAggregator.ModuleConfig[](1);
         disputers[0] = IPolymarketAggregator.ModuleConfig({
-            module: manifest.roles.disputerAndArbitratorModule, initData: bytes("")
+            module: manifest.roles.disputerAndArbitratorModule,
+            initData: bytes("")
         });
 
         params = IPolymarketAggregator.InitParams({
@@ -330,9 +333,8 @@ contract PolymarketV2EndToEndForkTest is Test {
         IPolymarketOOReporterLike.RequestData memory reporterRequest
     ) private view {
         {
-            Vm.Log memory registered = _event(
-                logs, manifest.reporter.proxy, REQUEST_REGISTERED_EVENT, requestId, "reporter RequestRegistered"
-            );
+            Vm.Log memory registered =
+                _event(logs, manifest.reporter.proxy, REQUEST_REGISTERED_EVENT, requestId, "reporter RequestRegistered");
             assertEq(_topicAddress(registered.topics[2]), manifest.reporterModule.proxy);
             assertEq(registered.topics[3], YES_OR_NO_QUERY);
             (bytes memory rules, uint64 minimumLiveness, uint64 maximumLiveness) =
@@ -456,9 +458,8 @@ contract PolymarketV2EndToEndForkTest is Test {
         }
 
         {
-            Vm.Log memory proposed = _event(
-                logs, manifest.aggregator.proxy, OUTCOME_PROPOSED_EVENT, requestId, "aggregator OutcomeProposed"
-            );
+            Vm.Log memory proposed =
+                _event(logs, manifest.aggregator.proxy, OUTCOME_PROPOSED_EVENT, requestId, "aggregator OutcomeProposed");
             (bytes32 resultHash, uint256[] memory result) = abi.decode(proposed.data, (bytes32, uint256[]));
             assertEq(resultHash, expectedProposalHash);
             assertEq(result, expectedProposal);

--- a/test/polymarket-v2/PolymarketV2Interfaces.sol
+++ b/test/polymarket-v2/PolymarketV2Interfaces.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IPolymarketAggregator {
+    enum ResolutionStatus {
+        None,
+        Active,
+        ArbitrationRequested,
+        Resolved
+    }
+
+    enum MarketType {
+        BINARY,
+        INCREMENTAL_NEGRISK,
+        ATOMIC_NEGRISK
+    }
+
+    struct ModuleConfig {
+        address module;
+        bytes initData;
+    }
+
+    struct InitParams {
+        bytes29 eventId;
+        MarketType marketType;
+        address targetContract;
+        uint16 resultLength;
+        ModuleConfig[] reporterModules;
+        uint16 reporterThreshold;
+        ModuleConfig[] disputerModules;
+        uint16 disputerThreshold;
+        address arbitratorModule;
+        bytes arbitratorInitData;
+        uint32 livenessWindow;
+        address finalizer;
+    }
+
+    function initializeRequest(InitParams calldata params) external;
+    function owner() external view returns (address);
+    function hasAllRoles(address user, uint256 roles) external view returns (bool);
+    function isReporterModule(bytes29 eventId, address module) external view returns (bool);
+    function isDisputerModule(bytes29 eventId, address module) external view returns (bool);
+    function getRequestShape(bytes32 requestId) external view returns (uint8 marketType, uint16 outcomeCount);
+    function getRequestState(bytes32 requestId)
+        external
+        view
+        returns (ResolutionStatus status, bytes32 proposedResultHash, uint256 disputeWindowEnd, uint256 disputeCount);
+}
+
+interface IOOReporterModuleLike {
+    struct RequestRegistration {
+        bytes32 requestId;
+        bytes requestRules;
+        uint64 minimumLiveness;
+        uint64 maximumLiveness;
+    }
+
+    function owner() external view returns (address);
+    function aggregator() external view returns (address);
+    function ooReporter() external view returns (address);
+    function hasAllRoles(address user, uint256 roles) external view returns (bool);
+    function requestInitialized(bytes31 scopeId) external view returns (bool);
+    function finalize(bytes32 requestId) external;
+}
+
+interface IPolymarketOOReporterLike {
+    struct RequestData {
+        uint256 requestTimestamp;
+        uint256 reward;
+        uint256 proposalBond;
+        uint64 liveness;
+        bool registered;
+        bool initialized;
+        bool resolved;
+        bool rerequestAllowed;
+        bool automaticDisputeRerequestUsed;
+        address requester;
+        address oracleInitializer;
+        bytes32 priceIdentifier;
+        bytes requestRules;
+        int256 outcome;
+        uint256 manualRerequestsRemaining;
+        uint64 minimumLiveness;
+        uint64 maximumLiveness;
+    }
+
+    function owner() external view returns (address);
+    function pendingOwner() external view returns (address);
+    function optimisticOracle() external view returns (address);
+    function rewardCurrency() external view returns (address);
+    function isRequester(address candidate) external view returns (bool);
+    function isOracleInitializer(address candidate) external view returns (bool);
+    function registerRequest(
+        bytes32 requestId,
+        bytes32 priceIdentifier,
+        bytes calldata requestRules,
+        uint64 minimumLiveness,
+        uint64 maximumLiveness
+    ) external;
+    function initializeRequest(bytes32 requestId, uint256 reward, uint256 proposalBond, uint64 liveness) external;
+    function isRequestResolved(bytes32 requestId) external view returns (bool);
+    function getRequestResolution(bytes32 requestId) external view returns (int256);
+    function getRequest(bytes32 requestId) external view returns (RequestData memory);
+}
+
+interface IManagedOptimisticOracleLike {
+    struct RequestSettings {
+        bool eventBased;
+        bool refundOnDispute;
+        bool callbackOnPriceProposed;
+        bool callbackOnPriceDisputed;
+        bool callbackOnPriceSettled;
+        uint256 bond;
+        uint256 customLiveness;
+    }
+
+    struct Request {
+        address proposer;
+        address disputer;
+        IERC20 currency;
+        bool settled;
+        RequestSettings requestSettings;
+        int256 proposedPrice;
+        int256 resolvedPrice;
+        uint256 expirationTime;
+        uint256 reward;
+        uint256 finalFee;
+        uint256 proposalTime;
+    }
+
+    function defaultAdmin() external view returns (address);
+    function defaultAdminDelay() external view returns (uint48);
+    function pendingDefaultAdmin() external view returns (address newAdmin, uint48 schedule);
+    function requesterWhitelist() external view returns (address);
+    function defaultProposerWhitelist() external view returns (address);
+    function hasRole(bytes32 role, address account) external view returns (bool);
+    function getRoleAdmin(bytes32 role) external view returns (bytes32);
+    function getRequest(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        view
+        returns (Request memory);
+    function proposePriceFor(
+        address proposer,
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory requestRules,
+        int256 proposedPrice
+    ) external returns (uint256 totalBond);
+    function settle(address requester, bytes32 identifier, uint256 timestamp, bytes memory requestRules)
+        external
+        returns (uint256 payout);
+}
+
+interface IAddressWhitelistLike {
+    function isOnWhitelist(address account) external view returns (bool);
+}
+
+interface IOwnableLike {
+    function owner() external view returns (address);
+}
+
+interface IBinaryModuleLike {
+    function hasAllRoles(address user, uint256 roles) external view returns (bool);
+    function getResult(bytes31 conditionId) external view returns (uint256[] memory);
+}
+
+interface IERC1822ProxiableLike {
+    function proxiableUUID() external view returns (bytes32);
+}

--- a/test/polymarket-v2/PolymarketV2Manifest.t.sol
+++ b/test/polymarket-v2/PolymarketV2Manifest.t.sol
@@ -4,10 +4,7 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 
 import {
-    CoreDeployment,
-    EnvironmentManifest,
-    EnvironmentManifestLib,
-    ExternalDeployment
+    CoreDeployment, EnvironmentManifest, EnvironmentManifestLib, ExternalDeployment
 } from "./EnvironmentManifest.sol";
 
 contract PolymarketV2ManifestTest is Test {

--- a/test/polymarket-v2/PolymarketV2Manifest.t.sol
+++ b/test/polymarket-v2/PolymarketV2Manifest.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {
+    CoreDeployment,
+    EnvironmentManifest,
+    EnvironmentManifestLib,
+    ExternalDeployment
+} from "./EnvironmentManifest.sol";
+
+contract PolymarketV2ManifestTest is Test {
+    string private constant VNET_MANIFEST = "test/polymarket-v2/environments/vnet.json";
+    string private constant AMOY_MANIFEST = "test/polymarket-v2/environments/amoy.json";
+
+    function test_manifestsAreVersionedAndContainNoRpcCredentials() public view {
+        EnvironmentManifest memory vnet = EnvironmentManifestLib.load(VNET_MANIFEST);
+        EnvironmentManifest memory amoy = EnvironmentManifestLib.load(AMOY_MANIFEST);
+
+        assertEq(vnet.schemaVersion, 2);
+        assertEq(amoy.schemaVersion, 2);
+        assertEq(vnet.chainId, 137);
+        assertEq(amoy.chainId, 80_002);
+        assertEq(vnet.rpcEnvironmentVariable, "FRO111_VNET_RPC_URL");
+        assertEq(amoy.rpcEnvironmentVariable, "FRO111_AMOY_RPC_URL");
+        assertEq(vnet.explorerEnvironmentVariable, "FRO111_VNET_EXPLORER_URL");
+        assertEq(amoy.explorerEnvironmentVariable, "FRO111_AMOY_EXPLORER_URL");
+        assertTrue(vnet.capabilities.snapshotStateVerified);
+        assertTrue(vnet.capabilities.automaticReporterCallback);
+        assertTrue(vnet.capabilities.reporterTwoStepOwnership);
+        assertTrue(vnet.capabilities.fullLifecycleSimulation);
+        assertTrue(amoy.capabilities.snapshotStateVerified);
+        assertFalse(amoy.capabilities.automaticReporterCallback);
+        assertFalse(amoy.capabilities.reporterTwoStepOwnership);
+        assertFalse(amoy.capabilities.fullLifecycleSimulation);
+        assertEq(vnet.knownBlockers.length, 0);
+        assertEq(amoy.knownBlockers.length, 3);
+
+        _assertSourceRevision(vnet.sources.managedOracle);
+        _assertSourceRevision(vnet.sources.managedOracleDeploymentTooling);
+        _assertSourceRevision(vnet.sources.ooReporterDeploymentTooling);
+        _assertSourceRevision(vnet.sources.polymarket);
+        _assertSourceRevision(vnet.sources.polymarketDeploymentConfig);
+        _assertSourceRevision(amoy.sources.managedOracle);
+        _assertSourceRevision(amoy.sources.managedOracleDeploymentTooling);
+        _assertSourceRevision(amoy.sources.ooReporterDeploymentTooling);
+        _assertSourceRevision(amoy.sources.polymarket);
+        _assertSourceRevision(amoy.sources.polymarketDeploymentConfig);
+        assertEq(vnet.testAbiBundle, "test/polymarket-v2/PolymarketV2Interfaces.sol");
+        assertEq(amoy.testAbiBundle, vnet.testAbiBundle);
+        assertEq(keccak256(bytes(EnvironmentManifestLib.raw(vnet.testAbiBundle))), vnet.testAbiBundleHash);
+        assertEq(amoy.testAbiBundleHash, vnet.testAbiBundleHash);
+
+        _assertDeployment(vnet.aggregator);
+        _assertDeployment(vnet.reporterModule);
+        _assertDeployment(vnet.reporter);
+        _assertDeployment(vnet.managedOracle);
+        _assertDeployment(vnet.binaryModule);
+        _assertDeployment(amoy.aggregator);
+        _assertDeployment(amoy.reporterModule);
+        _assertDeployment(amoy.reporter);
+        _assertDeployment(amoy.managedOracle);
+        _assertDeployment(amoy.binaryModule);
+        _assertExternalDeployment(vnet.rewardCurrency);
+        _assertExternalDeployment(vnet.requesterWhitelist);
+        _assertExternalDeployment(vnet.defaultProposerWhitelist);
+        _assertExternalDeployment(amoy.rewardCurrency);
+        _assertExternalDeployment(amoy.requesterWhitelist);
+        _assertExternalDeployment(amoy.defaultProposerWhitelist);
+
+        assertEq(vnet.roles.requiredAggregatorAdmins.length, 1);
+        assertEq(vnet.roles.requiredAggregatorOperators.length, 2);
+        assertEq(vnet.roles.requiredModuleAdmins.length, 1);
+        assertEq(vnet.roles.requiredModuleOperators.length, 1);
+        assertEq(vnet.roles.requiredManagedOracleResolvers.length, 3);
+        assertEq(amoy.roles.requiredAggregatorAdmins.length, 1);
+        assertEq(amoy.roles.requiredAggregatorOperators.length, 2);
+        assertEq(amoy.roles.requiredModuleAdmins.length, 1);
+        assertEq(amoy.roles.requiredModuleOperators.length, 0);
+        assertEq(amoy.roles.requiredManagedOracleResolvers.length, 1);
+
+        _assertNoCredentialMaterial(EnvironmentManifestLib.raw(VNET_MANIFEST));
+        _assertNoCredentialMaterial(EnvironmentManifestLib.raw(AMOY_MANIFEST));
+    }
+
+    function _assertSourceRevision(string memory revision) private pure {
+        assertEq(bytes(revision).length, 40, "source revision must be a full git SHA");
+    }
+
+    function _assertDeployment(CoreDeployment memory deployment) private pure {
+        assertTrue(bytes(deployment.repository).length > 0, "repository is required");
+        assertTrue(bytes(deployment.artifact).length > 0, "artifact is required");
+        assertTrue(bytes(deployment.sourcePath).length > 0, "source path is required");
+        _assertSourceRevision(deployment.sourceBlob);
+        assertTrue(bytes(deployment.proxyType).length > 0, "proxy type is required");
+        if (bytes(deployment.deploymentRecordRevision).length > 0) {
+            _assertSourceRevision(deployment.deploymentRecordRevision);
+        }
+        _assertSourceRevision(deployment.sourceRevision);
+        _assertSourceRevision(deployment.abiRevision);
+        assertTrue(deployment.proxy != address(0), "proxy is required");
+        assertTrue(deployment.implementation != address(0), "implementation is required");
+        assertTrue(deployment.upgradeAuthority != address(0), "upgrade authority is required");
+        assertGt(deployment.proxyDeploymentBlock, 0);
+        assertGt(deployment.implementationDeploymentBlock, 0);
+        assertGe(deployment.implementationActivationBlock, deployment.implementationDeploymentBlock);
+    }
+
+    function _assertExternalDeployment(ExternalDeployment memory deployment) private pure {
+        assertTrue(bytes(deployment.artifact).length > 0, "external artifact is required");
+        assertTrue(bytes(deployment.deploymentType).length > 0, "external deployment type is required");
+        assertTrue(deployment.contractAddress != address(0), "external address is required");
+        assertGt(deployment.deploymentBlock, 0);
+        assertTrue(deployment.codehash != bytes32(0), "external codehash is required");
+    }
+
+    function _assertNoCredentialMaterial(string memory manifest) private pure {
+        bytes memory raw = bytes(manifest);
+        assertFalse(_contains(raw, bytes("https://")), "manifest must not embed an RPC URL");
+        assertFalse(_contains(raw, bytes("http://")), "manifest must not embed an RPC URL");
+        assertFalse(_contains(raw, bytes("wss://")), "manifest must not embed a websocket URL");
+        assertFalse(_contains(raw, bytes("privateKey")), "manifest must not embed a private key");
+        assertFalse(_contains(raw, bytes("mnemonic")), "manifest must not embed a mnemonic");
+    }
+
+    function _contains(bytes memory haystack, bytes memory needle) private pure returns (bool) {
+        if (needle.length == 0 || needle.length > haystack.length) return false;
+
+        for (uint256 i; i <= haystack.length - needle.length; ++i) {
+            bool matches = true;
+            for (uint256 j; j < needle.length; ++j) {
+                if (haystack[i + j] != needle[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return true;
+        }
+        return false;
+    }
+}

--- a/test/polymarket-v2/PolymarketV2Wiring.Fork.t.sol
+++ b/test/polymarket-v2/PolymarketV2Wiring.Fork.t.sol
@@ -4,10 +4,7 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 
 import {
-    CoreDeployment,
-    EnvironmentManifest,
-    EnvironmentManifestLib,
-    ExternalDeployment
+    CoreDeployment, EnvironmentManifest, EnvironmentManifestLib, ExternalDeployment
 } from "./EnvironmentManifest.sol";
 import {
     IAddressWhitelistLike,

--- a/test/polymarket-v2/PolymarketV2Wiring.Fork.t.sol
+++ b/test/polymarket-v2/PolymarketV2Wiring.Fork.t.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {
+    CoreDeployment,
+    EnvironmentManifest,
+    EnvironmentManifestLib,
+    ExternalDeployment
+} from "./EnvironmentManifest.sol";
+import {
+    IAddressWhitelistLike,
+    IBinaryModuleLike,
+    IERC1822ProxiableLike,
+    IManagedOptimisticOracleLike,
+    IOOReporterModuleLike,
+    IOwnableLike,
+    IPolymarketAggregator,
+    IPolymarketOOReporterLike
+} from "./PolymarketV2Interfaces.sol";
+
+abstract contract PolymarketV2WiringForkBase is Test {
+    uint256 private constant ADMIN_ROLE = 1 << 0;
+    uint256 private constant OPERATOR_ROLE = 1 << 1;
+    uint256 private constant BINARY_RESOLVER_ROLE = 1 << 4;
+    bytes32 private constant MANAGED_ORACLE_CONFIG_ADMIN_ROLE = keccak256("CONFIG_ADMIN_ROLE");
+    bytes32 private constant MANAGED_ORACLE_REQUEST_MANAGER_ROLE = keccak256("REQUEST_MANAGER_ROLE");
+    bytes32 private constant MANAGED_ORACLE_RESOLVER_ROLE = keccak256("RESOLVER_ROLE");
+    bytes32 private constant MANAGED_ORACLE_RESOLVER_ADMIN_ROLE = keccak256("RESOLVER_ADMIN_ROLE");
+    bytes32 private constant DEFAULT_ADMIN_ROLE = bytes32(0);
+    bytes4 private constant UNAUTHORIZED_SELECTOR = bytes4(keccak256("Unauthorized()"));
+    bytes32 private constant ERC1967_IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    bytes32 private constant ERC1967_ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    EnvironmentManifest internal manifest;
+    string internal rpcUrl;
+    bool internal forkEnabled;
+    bool internal pinnedSnapshot;
+
+    function setUp() public virtual {
+        manifest = EnvironmentManifestLib.load(_manifestPath());
+        rpcUrl = vm.envOr(manifest.rpcEnvironmentVariable, string(""));
+        if (bytes(rpcUrl).length == 0) return;
+
+        if (_useLatestState()) {
+            vm.createSelectFork(rpcUrl);
+        } else {
+            _assertSnapshotHash();
+            vm.createSelectFork(rpcUrl, manifest.snapshotBlock);
+            pinnedSnapshot = true;
+        }
+        forkEnabled = true;
+    }
+
+    function test_wiringAndRolesMatchManifest() public {
+        if (!_requireFork()) return;
+
+        assertEq(block.chainid, manifest.chainId);
+        if (pinnedSnapshot) assertEq(block.number, manifest.snapshotBlock);
+
+        _assertDeployment(manifest.aggregator);
+        _assertDeployment(manifest.reporterModule);
+        _assertDeployment(manifest.reporter);
+        _assertDeployment(manifest.managedOracle);
+        _assertDeployment(manifest.binaryModule);
+        _assertExternalDeployment(manifest.rewardCurrency);
+        _assertExternalDeployment(manifest.requesterWhitelist);
+        _assertExternalDeployment(manifest.defaultProposerWhitelist);
+
+        IPolymarketAggregator aggregator = IPolymarketAggregator(manifest.aggregator.proxy);
+        IOOReporterModuleLike reporterModule = IOOReporterModuleLike(manifest.reporterModule.proxy);
+        IPolymarketOOReporterLike reporter = IPolymarketOOReporterLike(manifest.reporter.proxy);
+        IManagedOptimisticOracleLike managedOracle = IManagedOptimisticOracleLike(manifest.managedOracle.proxy);
+
+        assertEq(reporterModule.aggregator(), address(aggregator));
+        assertEq(reporterModule.ooReporter(), address(reporter));
+        assertEq(reporter.optimisticOracle(), address(managedOracle));
+        assertEq(reporter.rewardCurrency(), manifest.rewardCurrency.contractAddress);
+        assertTrue(reporter.isRequester(address(reporterModule)));
+        assertEq(managedOracle.requesterWhitelist(), manifest.requesterWhitelist.contractAddress);
+        assertEq(managedOracle.defaultProposerWhitelist(), manifest.defaultProposerWhitelist.contractAddress);
+        assertTrue(IAddressWhitelistLike(manifest.requesterWhitelist.contractAddress).isOnWhitelist(address(reporter)));
+        assertEq(
+            IOwnableLike(manifest.requesterWhitelist.contractAddress).owner(), manifest.roles.requesterWhitelistOwner
+        );
+        assertEq(
+            IOwnableLike(manifest.defaultProposerWhitelist.contractAddress).owner(),
+            manifest.roles.defaultProposerWhitelistOwner
+        );
+
+        assertEq(aggregator.owner(), manifest.roles.aggregatorOwner);
+        assertEq(reporterModule.owner(), manifest.roles.moduleOwner);
+        assertEq(reporter.owner(), manifest.roles.reporterOwner);
+        if (manifest.capabilities.reporterTwoStepOwnership) {
+            assertEq(reporter.pendingOwner(), manifest.roles.reporterPendingOwner);
+        }
+        assertEq(managedOracle.defaultAdmin(), manifest.roles.managedOracleDefaultAdmin);
+        assertEq(uint256(managedOracle.defaultAdminDelay()), manifest.roles.managedOracleDefaultAdminDelay);
+        (address pendingDefaultAdmin, uint48 pendingSchedule) = managedOracle.pendingDefaultAdmin();
+        assertEq(pendingDefaultAdmin, manifest.roles.managedOraclePendingDefaultAdmin);
+        assertEq(uint256(pendingSchedule), manifest.roles.managedOraclePendingDefaultAdminSchedule);
+        assertEq(manifest.aggregator.upgradeAuthority, manifest.roles.aggregatorOwner);
+        assertEq(manifest.reporterModule.upgradeAuthority, manifest.roles.moduleOwner);
+        assertEq(manifest.reporter.upgradeAuthority, manifest.roles.reporterOwner);
+        assertEq(manifest.managedOracle.upgradeAuthority, manifest.roles.managedOracleDefaultAdmin);
+        assertTrue(
+            IBinaryModuleLike(manifest.binaryModule.proxy).hasAllRoles(address(aggregator), BINARY_RESOLVER_ROLE),
+            "aggregator must resolve the binary target"
+        );
+
+        for (uint256 i; i < manifest.roles.requiredAggregatorAdmins.length; ++i) {
+            assertTrue(aggregator.hasAllRoles(manifest.roles.requiredAggregatorAdmins[i], ADMIN_ROLE));
+        }
+        for (uint256 i; i < manifest.roles.requiredAggregatorOperators.length; ++i) {
+            assertTrue(aggregator.hasAllRoles(manifest.roles.requiredAggregatorOperators[i], OPERATOR_ROLE));
+        }
+        for (uint256 i; i < manifest.roles.requiredModuleAdmins.length; ++i) {
+            assertTrue(reporterModule.hasAllRoles(manifest.roles.requiredModuleAdmins[i], ADMIN_ROLE));
+        }
+        for (uint256 i; i < manifest.roles.requiredModuleOperators.length; ++i) {
+            assertTrue(reporterModule.hasAllRoles(manifest.roles.requiredModuleOperators[i], OPERATOR_ROLE));
+        }
+        for (uint256 i; i < manifest.roles.requiredOracleInitializersAndProposers.length; ++i) {
+            address account = manifest.roles.requiredOracleInitializersAndProposers[i];
+            assertTrue(reporter.isOracleInitializer(account));
+            assertTrue(IAddressWhitelistLike(managedOracle.defaultProposerWhitelist()).isOnWhitelist(account));
+        }
+        for (uint256 i; i < manifest.roles.requiredManagedOracleConfigAdmins.length; ++i) {
+            assertTrue(
+                managedOracle.hasRole(
+                    MANAGED_ORACLE_CONFIG_ADMIN_ROLE, manifest.roles.requiredManagedOracleConfigAdmins[i]
+                )
+            );
+        }
+        for (uint256 i; i < manifest.roles.requiredManagedOracleRequestManagers.length; ++i) {
+            assertTrue(
+                managedOracle.hasRole(
+                    MANAGED_ORACLE_REQUEST_MANAGER_ROLE, manifest.roles.requiredManagedOracleRequestManagers[i]
+                )
+            );
+        }
+        for (uint256 i; i < manifest.roles.requiredManagedOracleResolverAdmins.length; ++i) {
+            assertTrue(
+                managedOracle.hasRole(
+                    MANAGED_ORACLE_RESOLVER_ADMIN_ROLE, manifest.roles.requiredManagedOracleResolverAdmins[i]
+                )
+            );
+        }
+        for (uint256 i; i < manifest.roles.requiredManagedOracleResolvers.length; ++i) {
+            assertTrue(
+                managedOracle.hasRole(MANAGED_ORACLE_RESOLVER_ROLE, manifest.roles.requiredManagedOracleResolvers[i])
+            );
+        }
+
+        assertEq(managedOracle.getRoleAdmin(MANAGED_ORACLE_CONFIG_ADMIN_ROLE), DEFAULT_ADMIN_ROLE);
+        assertEq(managedOracle.getRoleAdmin(MANAGED_ORACLE_REQUEST_MANAGER_ROLE), MANAGED_ORACLE_CONFIG_ADMIN_ROLE);
+        assertEq(managedOracle.getRoleAdmin(MANAGED_ORACLE_RESOLVER_ROLE), MANAGED_ORACLE_RESOLVER_ADMIN_ROLE);
+        assertEq(managedOracle.getRoleAdmin(MANAGED_ORACLE_RESOLVER_ADMIN_ROLE), MANAGED_ORACLE_RESOLVER_ADMIN_ROLE);
+    }
+
+    function test_deploymentAndActivationBlocksMatchManifest() public {
+        if (!_requireFork()) return;
+        if (!pinnedSnapshot) {
+            vm.skip(true, "latest-state mode cannot verify historical deployment blocks");
+            return;
+        }
+
+        _assertDeploymentHistory(manifest.aggregator);
+        _assertDeploymentHistory(manifest.reporterModule);
+        _assertDeploymentHistory(manifest.reporter);
+        _assertDeploymentHistory(manifest.managedOracle);
+        _assertDeploymentHistory(manifest.binaryModule);
+        _assertFirstCodeBlock(
+            manifest.rewardCurrency.contractAddress,
+            manifest.rewardCurrency.deploymentBlock,
+            "reward currency deployment block mismatch"
+        );
+        _assertFirstCodeBlock(
+            manifest.requesterWhitelist.contractAddress,
+            manifest.requesterWhitelist.deploymentBlock,
+            "requester whitelist deployment block mismatch"
+        );
+        _assertFirstCodeBlock(
+            manifest.defaultProposerWhitelist.contractAddress,
+            manifest.defaultProposerWhitelist.deploymentBlock,
+            "default proposer whitelist deployment block mismatch"
+        );
+    }
+
+    function test_unauthorizedAggregatorInitializationIsRejected() public {
+        if (!_requireFork()) return;
+
+        IPolymarketAggregator.ModuleConfig[] memory modules = new IPolymarketAggregator.ModuleConfig[](0);
+        IPolymarketAggregator.InitParams memory params = IPolymarketAggregator.InitParams({
+            eventId: bytes29(0),
+            marketType: IPolymarketAggregator.MarketType.BINARY,
+            targetContract: manifest.binaryModule.proxy,
+            resultLength: 1,
+            reporterModules: modules,
+            reporterThreshold: 1,
+            disputerModules: modules,
+            disputerThreshold: 1,
+            arbitratorModule: manifest.roles.disputerAndArbitratorModule,
+            arbitratorInitData: bytes(""),
+            livenessWindow: 1 hours,
+            finalizer: manifest.reporterModule.proxy
+        });
+
+        vm.expectRevert(UNAUTHORIZED_SELECTOR);
+        vm.prank(address(0xBEEF));
+        IPolymarketAggregator(manifest.aggregator.proxy).initializeRequest(params);
+    }
+
+    function _requireFork() internal returns (bool) {
+        if (forkEnabled) return true;
+        vm.skip(true, string.concat("set ", manifest.rpcEnvironmentVariable, " to run this read-only fork test"));
+        return false;
+    }
+
+    function _assertDeployment(CoreDeployment memory deployment) private view {
+        assertTrue(bytes(deployment.repository).length > 0, "missing deployment repository");
+        assertTrue(bytes(deployment.artifact).length > 0, "missing deployment artifact");
+        assertTrue(bytes(deployment.sourcePath).length > 0, "missing deployment source path");
+        assertEq(bytes(deployment.sourceBlob).length, 40, "invalid deployment source blob");
+        if (bytes(deployment.deploymentRecordRevision).length > 0) {
+            assertEq(bytes(deployment.deploymentRecordRevision).length, 40, "invalid deployment record revision");
+        }
+        assertEq(bytes(deployment.sourceRevision).length, 40, "invalid deployment source revision");
+        assertEq(bytes(deployment.abiRevision).length, 40, "invalid ABI revision");
+        assertTrue(bytes(deployment.proxyType).length > 0, "missing proxy type");
+        assertTrue(deployment.proxy.code.length > 0, "proxy has no code");
+        assertTrue(deployment.implementation.code.length > 0, "implementation has no code");
+        assertEq(deployment.proxy.codehash, deployment.proxyCodehash, "proxy codehash mismatch");
+        assertEq(
+            deployment.implementation.codehash, deployment.implementationCodehash, "implementation codehash mismatch"
+        );
+        assertEq(
+            address(uint160(uint256(vm.load(deployment.proxy, ERC1967_IMPLEMENTATION_SLOT)))),
+            deployment.implementation,
+            "implementation slot mismatch"
+        );
+        assertEq(address(uint160(uint256(vm.load(deployment.proxy, ERC1967_ADMIN_SLOT)))), deployment.proxyAdmin);
+        assertEq(deployment.proxyAdmin, address(0), "UUPS proxy must not have a transparent proxy admin");
+        assertEq(IERC1822ProxiableLike(deployment.implementation).proxiableUUID(), ERC1967_IMPLEMENTATION_SLOT);
+    }
+
+    function _assertExternalDeployment(ExternalDeployment memory deployment) private view {
+        assertTrue(bytes(deployment.artifact).length > 0, "missing external artifact");
+        assertTrue(bytes(deployment.deploymentType).length > 0, "missing external deployment type");
+        assertTrue(deployment.contractAddress.code.length > 0, "external dependency has no code");
+        assertEq(deployment.contractAddress.codehash, deployment.codehash, "external dependency codehash mismatch");
+    }
+
+    function _assertSnapshotHash() private {
+        vm.createSelectFork(rpcUrl, manifest.snapshotBlock + 1);
+        assertEq(blockhash(manifest.snapshotBlock), manifest.snapshotBlockHash, "snapshot hash mismatch");
+    }
+
+    function _assertDeploymentHistory(CoreDeployment memory deployment) private {
+        _assertFirstCodeBlock(deployment.proxy, deployment.proxyDeploymentBlock, "proxy deployment block mismatch");
+        _assertFirstCodeBlock(
+            deployment.implementation,
+            deployment.implementationDeploymentBlock,
+            "implementation deployment block mismatch"
+        );
+
+        bytes32 beforeActivation = _implementationAt(deployment.proxy, deployment.implementationActivationBlock - 1);
+        bytes32 atActivation = _implementationAt(deployment.proxy, deployment.implementationActivationBlock);
+        assertTrue(
+            address(uint160(uint256(beforeActivation))) != deployment.implementation,
+            "implementation active before manifest block"
+        );
+        assertEq(
+            address(uint160(uint256(atActivation))),
+            deployment.implementation,
+            "implementation activation block mismatch"
+        );
+    }
+
+    function _assertFirstCodeBlock(address target, uint256 deploymentBlock, string memory message) private {
+        bytes memory beforeDeployment = vm.rpc(
+            rpcUrl,
+            "eth_getCode",
+            string.concat("[\"", vm.toString(target), "\",\"", _rpcQuantity(deploymentBlock - 1), "\"]")
+        );
+        bytes memory atDeployment = vm.rpc(
+            rpcUrl,
+            "eth_getCode",
+            string.concat("[\"", vm.toString(target), "\",\"", _rpcQuantity(deploymentBlock), "\"]")
+        );
+        assertEq(beforeDeployment.length, 0, message);
+        assertGt(atDeployment.length, 0, message);
+    }
+
+    function _implementationAt(address proxy, uint256 blockNumber) private returns (bytes32) {
+        bytes memory value = vm.rpc(
+            rpcUrl,
+            "eth_getStorageAt",
+            string.concat(
+                "[\"",
+                vm.toString(proxy),
+                "\",\"",
+                vm.toString(ERC1967_IMPLEMENTATION_SLOT),
+                "\",\"",
+                _rpcQuantity(blockNumber),
+                "\"]"
+            )
+        );
+        return abi.decode(value, (bytes32));
+    }
+
+    function _rpcQuantity(uint256 value) private pure returns (string memory) {
+        if (value == 0) return "0x0";
+
+        bytes16 symbols = "0123456789abcdef";
+        uint256 length;
+        for (uint256 copy = value; copy != 0; copy >>= 4) {
+            ++length;
+        }
+
+        bytes memory result = new bytes(length + 2);
+        result[0] = "0";
+        result[1] = "x";
+        for (uint256 i = length + 1; i > 1; --i) {
+            result[i] = symbols[value & 0xf];
+            value >>= 4;
+        }
+        return string(result);
+    }
+
+    function _manifestPath() internal pure virtual returns (string memory);
+
+    function _useLatestState() internal view virtual returns (bool) {
+        return false;
+    }
+}
+
+contract PolymarketV2VNetWiringForkTest is PolymarketV2WiringForkBase {
+    function _manifestPath() internal pure override returns (string memory) {
+        return "test/polymarket-v2/environments/vnet.json";
+    }
+}
+
+contract PolymarketV2AmoyWiringForkTest is PolymarketV2WiringForkBase {
+    function _manifestPath() internal pure override returns (string memory) {
+        return "test/polymarket-v2/environments/amoy.json";
+    }
+
+    function _useLatestState() internal view override returns (bool) {
+        return vm.envOr("FRO111_AMOY_USE_LATEST", false);
+    }
+}

--- a/test/polymarket-v2/README.md
+++ b/test/polymarket-v2/README.md
@@ -1,0 +1,224 @@
+# Polymarket v2 end-to-end contract environment
+
+This fixture validates the deployed Polymarket v2 oracle stack against versioned VNet and Amoy
+manifests. The VNet test covers the full path from Polymarket request registration through Managed
+OO settlement, the automatic OOReporter callback, aggregator finalization, and the binary payout.
+
+## Safety guarantee
+
+The tests use `vm.createSelectFork` to pull remote state into Forge's local EVM. Every call,
+impersonation, balance change, deployment, and timestamp change after that happens only in the
+local test process and is discarded when the process exits.
+
+This workflow must not contain `cast send`, `--broadcast`, a private key, a signer, Tenderly
+impersonation methods, or any `eth_send*` RPC method. It intentionally produces no remote
+transaction hash. `vm.prank`, `deal`, and `vm.warp` are Forge-local operations, not RPC writes.
+
+## Environment configuration
+
+Bootstrap a clean checkout first:
+
+```sh
+git submodule update --init --recursive
+git clone https://github.com/Polymarket/polymarket-v2.git ../polymarket-v2
+export FRO111_POLYMARKET_REPO="$(cd ../polymarket-v2 && pwd)"
+bash test/polymarket-v2/check-provenance.sh
+```
+
+An existing full Polymarket checkout can be used instead of cloning another copy. The provenance
+check resolves every declared commit, deployment-record commit, source path, and Git source blob in
+its owning repository. It fails before RPC testing if any source/ABI association is stale or
+incorrect.
+
+Then copy the variable names from `env.example` into the shell and populate them locally. The RPCs
+must support historical reads at the manifest blocks. Explorer variables are optional reference
+keys; the tests do not contact an explorer.
+
+| Environment | RPC variable | Explorer variable | Purpose |
+| --- | --- | --- | --- |
+| Staging VNet | `FRO111_VNET_RPC_URL` | `FRO111_VNET_EXPLORER_URL` | Exact post-audit lifecycle replay |
+| Amoy | `FRO111_AMOY_RPC_URL` | `FRO111_AMOY_EXPLORER_URL` | Exact wiring, history, roles, and authorization subset |
+
+No endpoint, token, service credential, or private key is stored in the manifests.
+
+## Versioned inventory and provenance
+
+Each integration-owned deployment (aggregator, reporter module, reporter, Managed OO, and binary
+module) records:
+
+- proxy and implementation addresses, raw runtime code hashes, first-code blocks, and the current
+  implementation activation block;
+- proxy family, ERC-1967 admin slot expectation, and effective UUPS upgrade authority;
+- canonical source artifact plus full source and ABI revisions;
+- immutable Git source-blob ID and the deployment-record/tooling revision when one exists;
+- the chain, snapshot height and hash, dependencies, ownership, allowlists, required operational
+  role holders, capabilities, and unresolved blockers.
+
+The external reward token and both UMA whitelists are also pinned by address, first-code block,
+runtime code hash, and deployment topology. Their minimal ABI surfaces are part of the pinned local
+test interface bundle; their external source/build provenance is not claimed by this fixture.
+
+The onchain code hash and block data are authoritative. Source and ABI revisions identify the
+corresponding source surface; they are not presented as a compiler proof when the original build
+artifact was not retained. `testAbiBundle.keccak256` pins the exact local interface bundle exercised
+by these tests. The Amoy Managed OO source mapping is explicitly marked as inferred because its
+original broadcast/build artifact was not versioned.
+
+The VNet BinaryModule slot was restored to the recorded Polygon implementation at block 87,924,763
+without an `Upgraded` log, as part of the fork's configured state. The manifest therefore records
+that exact slot-transition block as the current implementation activation point; block 85,313,858
+remains the implementation's first deployment and initial proxy activation.
+
+## Commands
+
+Validate both manifests without an RPC:
+
+```sh
+forge test --match-contract PolymarketV2ManifestTest -vv
+```
+
+Validate the exact VNet snapshot, deployment history, proxy topology, wiring, roles, and negative
+authorization case:
+
+```sh
+forge test --match-contract PolymarketV2VNetWiringForkTest -vv
+```
+
+Run the full VNet lifecycle in the local EVM:
+
+```sh
+forge test --match-contract PolymarketV2EndToEndForkTest -vv
+```
+
+Validate the equivalent supported subset against the exact Amoy snapshot:
+
+```sh
+forge test --match-contract PolymarketV2AmoyWiringForkTest -vv
+```
+
+If an Amoy endpoint serves only current state, current wiring can still be checked explicitly:
+
+```sh
+FRO111_AMOY_USE_LATEST=true \
+  forge test --match-contract PolymarketV2AmoyWiringForkTest -vv
+```
+
+Latest-state mode deliberately skips historical deployment/activation checks and is not accepted
+as an exact replay. The existing Polygon fork CI job does not set either FRO-111 RPC variable, so
+these tests skip cleanly instead of accidentally using Polygon mainnet.
+
+## Automated checks
+
+The exact wiring suites fail on any mismatch in:
+
+- chain ID, snapshot number, or snapshot hash; the hash is read with `blockhash` from a local fork
+  at the following block;
+- first proxy/implementation code blocks and implementation activation blocks, using read-only
+  `eth_getCode` and `eth_getStorageAt` calls;
+- runtime code hashes, ERC-1967 implementation/admin slots, and ERC-1822 UUIDs;
+- owners, pending transfers, upgrade authorities, three-day Managed OO default-admin delay, and
+  role-admin hierarchy; VNet's reporter is two-step-owned while the older Amoy reporter is not;
+- aggregator/module admins and operators; Managed OO config, request-manager, resolver-admin, and
+  resolver roles;
+- module → reporter → Managed OO bindings, requester and proposer allowlists, and binary-module
+  resolver permission;
+- rejection of aggregator initialization from an unrelated address.
+
+The role arrays are the operational principals required by this integration. The Staging VNet
+also contains ephemeral test aggregator operators created by other scenarios; they are not used as
+deployment authorities or lifecycle actors here.
+
+## VNet lifecycle
+
+The fixed fixture derives a canonical binary request ID from
+`uma-fro-111-polymarket-v2-e2e-binary-v1` and proves it is unused at the pinned snapshot. The test
+then performs the following only in Forge's local EVM:
+
+1. An active aggregator operator initializes the binary request and registers the live
+   `OOReporterModule` through its initializer payload.
+2. The UMA initializer creates an event-based Managed OO request with the configured identifier,
+   rules, and liveness bounds.
+3. Forge locally funds the proposer with exactly the bond plus final fee and grants a local token
+   allowance.
+4. The proposer submits `YES`; local time advances; an active resolver settles the request.
+5. `PolymarketOOReporter` stores the outcome and automatically calls the reporter module, which
+   translates and submits the result to the aggregator.
+6. Local time advances through the aggregator window; the module finalizes; the binary module
+   stores `[1_000_000, 0]`.
+
+The test also asserts `requestInitialized`, reporter/disputer module membership, request shape,
+identifier, rules, minimum/maximum/custom liveness, proposal bond, payout, result hash, vote count,
+and final binary result.
+
+## Lifecycle event evidence
+
+`PolymarketV2EndToEndForkTest` captures and decodes the local EVM logs rather than checking only
+event signatures. These fields are asserted and form the initial indexer contract:
+
+| Contract | Events | Asserted fields |
+| --- | --- | --- |
+| Managed OO | `RequestPrice`, `ProposePrice`, `Settle` | requester, proposer/disputer, identifier, timestamp, rules, currency, reward/final fee, price, expiration, payout |
+| OOReporter | `RequestRegistered`, `RequestInitialized`, `RequestResolved`, `ReportCallbackSucceeded` | request ID, requester, initializer, identifier, rules, liveness bounds, reward/bond, budget, outcome, callback module |
+| OOReporterModule | `OOReporterRequestCreated`, `OOReporterResultReported` | request ID, identifier, price, translated result hash |
+| OracleAggregator | `RequestInitialized`, `ResultReported`, `OutcomeProposed`, `RequestResolved` | event/request ID, target, thresholds, shape, modules, liveness, finalizer, result, hash, votes, resolver |
+
+The evidence is deterministic local-fork evidence, not a remote transaction receipt. Rerunning at
+the pinned block reproduces the same state transitions and decoded values without mutating the
+VNet.
+
+## Operational ownership and setup
+
+The wiring test is the idempotent setup check: rerun it before any lifecycle work. All required
+VNet roles and all supported Amoy roles currently pass.
+
+| Capability | VNet authority/actor | Amoy authority/actor |
+| --- | --- | --- |
+| Aggregator/module UUPS upgrade | `0x47Eb...629C` owner | `0xfCBF...3D02` owner |
+| Aggregator/module admin | `0x3dcE...D952` | `0xcA71...38A1` |
+| Lifecycle aggregator operator | `0x1b41...f3f4` | `0xac99...5294`, `0x8c7c...a73c` |
+| Module operator | `0xac99...5294` | Missing; admin `0xcA71...38A1` can grant it after a recipient is selected |
+| Reporter UUPS/requester/initializer config | `0x9A8...b04D` owner | `0x9A8...b04D` owner |
+| Requester whitelist changes | `0x3dcE...D952` | `0x9A8...b04D` |
+| Default proposer whitelist changes | `0x6ee4...4146` | `0x9A8...b04D` |
+| Managed OO upgrade/default admin | `0x9A8...b04D` | `0x9A8...b04D` |
+| Managed OO config/request manager | `0x3dcE...D952` / `0x9A8...b04D` | `0x9A8...b04D` |
+| Managed OO resolver admin/resolver | `0x6ee4...4146` / three manifest resolvers | `0x9A8...b04D` |
+
+The only missing Amoy role is a module operator. After choosing the recipient, its calldata can be
+prepared locally without sending it:
+
+```sh
+cast calldata "addOperator(address)" <selected-operator>
+```
+
+The module owner/admin must review and execute any eventual configuration transaction outside this
+read-only workflow. Upgrading Amoy from base `OOReporter` to `PolymarketOOReporter` likewise requires
+the reporter owner and a reviewed implementation; it is not performed here.
+
+## Funding and gas
+
+The VNet simulation needs no remote funding or gas. Forge's `deal` supplies exactly 500,000,000
+reward-token base units (500 USDC.e at six decimals) for the bond plus final fee, and all approvals
+remain local. A real testnet lifecycle would require native gas for each operator/proposer/resolver
+and reward currency plus allowance for the proposer, but remote execution is deliberately outside
+this fixture.
+
+## Amoy scope and blockers
+
+The exact Amoy snapshot passes deployment-history, topology, wiring, role, allowlist, and
+unauthorized-initialization tests. It cannot run the automatic lifecycle because:
+
+- the proxy points to base `OOReporter`, which has no automatic Polymarket callback;
+- `OOReporterModule` has no selected operator for future module configuration;
+- the current Managed OO deployment lacks a versioned original broadcast/build artifact, so its
+  source mapping remains documented as an inference while the onchain code hash is authoritative.
+
+## Replay, reset, and VNet recreation
+
+Rerun the same Forge command to reset. Every test starts from the immutable snapshot and discards
+all local writes; no cleanup transaction is needed or permitted.
+
+If the VNet is recreated or any deployment changes, create a new manifest snapshot. Record the new
+block and following block, verify the new hash, re-discover every first-code and activation block,
+refresh all code hashes/roles/allowlists, choose an unused fixture ID, and rerun both wiring and E2E
+tests. Do not silently repoint an existing manifest or replace an exact snapshot with latest state.

--- a/test/polymarket-v2/check-provenance.sh
+++ b/test/polymarket-v2/check-provenance.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+managed_oracle_repo=$(git rev-parse --show-toplevel)
+polymarket_repo=${FRO111_POLYMARKET_REPO:-}
+
+if [[ -z "$polymarket_repo" || ! -d "$polymarket_repo/.git" ]]; then
+  echo "FRO111_POLYMARKET_REPO must point to a full Polymarket/polymarket-v2 checkout" >&2
+  exit 1
+fi
+
+require_commit() {
+  local repo=$1
+  local revision=$2
+  git -C "$repo" cat-file -e "${revision}^{commit}"
+}
+
+for manifest in \
+  "$managed_oracle_repo/test/polymarket-v2/environments/vnet.json" \
+  "$managed_oracle_repo/test/polymarket-v2/environments/amoy.json"
+do
+  while IFS=$'\t' read -r repository source_path source_blob deployment_record source_revision abi_revision
+  do
+    case "$repository" in
+      UMAprotocol/managed-oracle) source_repo=$managed_oracle_repo ;;
+      Polymarket/polymarket-v2) source_repo=$polymarket_repo ;;
+      *) echo "unsupported repository in manifest: $repository" >&2; exit 1 ;;
+    esac
+
+    require_commit "$source_repo" "$source_revision"
+    require_commit "$source_repo" "$abi_revision"
+    if [[ "$deployment_record" != "-" ]]; then
+      require_commit "$source_repo" "$deployment_record"
+    fi
+
+    actual_source_blob=$(git -C "$source_repo" rev-parse "${source_revision}:${source_path}")
+    actual_abi_blob=$(git -C "$source_repo" rev-parse "${abi_revision}:${source_path}")
+    if [[ "$actual_source_blob" != "$source_blob" || "$actual_abi_blob" != "$source_blob" ]]; then
+      echo "source/ABI blob mismatch for $repository@$source_revision:$source_path" >&2
+      exit 1
+    fi
+  done < <(
+    jq -r '.contracts | to_entries[] | select(.value | type == "object" and has("repository")) | [
+      .value.repository,
+      .value.sourcePath,
+      .value.sourceBlob,
+      (.value.deploymentRecordRevision // "" | if length == 0 then "-" else . end),
+      .value.sourceRevision,
+      .value.abiRevision
+    ] | @tsv' "$manifest"
+  )
+done
+
+while read -r revision; do
+  require_commit "$managed_oracle_repo" "$revision"
+done < <(
+  jq -r '.sources | .managedOracle, .managedOracleDeploymentTooling, .ooReporterDeploymentTooling' \
+    "$managed_oracle_repo/test/polymarket-v2/environments/vnet.json"
+)
+
+while read -r revision; do
+  require_commit "$polymarket_repo" "$revision"
+done < <(
+  jq -r '.sources | .polymarket, .polymarketDeploymentConfig' \
+    "$managed_oracle_repo/test/polymarket-v2/environments/vnet.json"
+)
+
+echo "FRO-111 source, ABI, deployment-record, and blob provenance verified"

--- a/test/polymarket-v2/env.example
+++ b/test/polymarket-v2/env.example
@@ -1,0 +1,10 @@
+# Read-only JSON-RPC endpoints. Do not commit populated values.
+export FRO111_VNET_RPC_URL="<archive-capable-staging-vnet-rpc>"
+export FRO111_AMOY_RPC_URL="<archive-capable-amoy-rpc>"
+
+# Optional public explorer base URLs for manual evidence links. Tests do not consume them.
+export FRO111_VNET_EXPLORER_URL="<staging-vnet-explorer-base-url>"
+export FRO111_AMOY_EXPLORER_URL="<amoy-explorer-base-url>"
+
+# Optional: verify current Amoy wiring when only a non-archive RPC is available.
+export FRO111_AMOY_USE_LATEST=false

--- a/test/polymarket-v2/environments/amoy.json
+++ b/test/polymarket-v2/environments/amoy.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": 2,
+  "environment": "polymarket-v2-amoy",
+  "purpose": "Public testnet wiring and authorization smoke checks for the Polymarket v2 oracle stack.",
+  "chainId": 80002,
+  "rpcEnvironmentVariable": "FRO111_AMOY_RPC_URL",
+  "explorer": {
+    "name": "PolygonScan Amoy",
+    "baseUrlEnvironmentVariable": "FRO111_AMOY_EXPLORER_URL"
+  },
+  "snapshot": {
+    "blockNumber": 44114794,
+    "rpcBlockNumber": "0x2a1236a",
+    "blockHash": "0x2cb26d0bccddd8e93324a4f7d49646422caabb098b1a7a5239bba1e1e8a72593"
+  },
+  "sources": {
+    "managedOracle": "19e06f085d95cf18101c274205298b73dfc295f3",
+    "managedOracleDeploymentTooling": "59f5f91271b3aac7c6fa1744fb84f407ad24980b",
+    "ooReporterDeploymentTooling": "7044bf9effe21de353b023e2426131ace9f0e826",
+    "polymarket": "11627f7629543e1efdcc2bb6ee0d7576834c4931",
+    "polymarketDeploymentConfig": "0896b9ed73cfb7fa3470c6822571ab0dce3d43f1"
+  },
+  "testAbiBundle": {
+    "path": "test/polymarket-v2/PolymarketV2Interfaces.sol",
+    "keccak256": "0x6e410ef356da3aeba25137466b2e6768d560c1128a4a5294337b7c5c9748eed3"
+  },
+  "contracts": {
+    "aggregator": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/oracle/OracleAggregator.sol:OracleAggregator",
+      "sourcePath": "src/oracle/OracleAggregator.sol",
+      "sourceBlob": "353fef3e0e999a22d05776a9ad2d6f1247c47392",
+      "deploymentRecordRevision": "81e913360987a32422abd303e2756bc2e659f537",
+      "sourceRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "abiRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0x0A0a0A0A8B00C51b7D810501b03F230028C04a87",
+      "implementation": "0x1998bfA62C8A705A2283cFE52EBD095c95b0C594",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0xfCBF369998693b075837234706DD9453c3563D02",
+      "proxyDeploymentBlock": 43538727,
+      "implementationDeploymentBlock": 43538557,
+      "implementationActivationBlock": 43538727,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x3e372ad260ad63c29d52cd7e2047f172756816d190602e9a2c277e3d5c336a0a"
+    },
+    "reporterModule": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/oracle/modules/OOReporterModule.sol:OOReporterModule",
+      "sourcePath": "src/oracle/modules/OOReporterModule.sol",
+      "sourceBlob": "8865093bda976cc4384a79c06c7c48011ffb0c81",
+      "deploymentRecordRevision": "0896b9ed73cfb7fa3470c6822571ab0dce3d43f1",
+      "sourceRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "abiRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0xC955D42bBd36F909Cd457847c6e8d798872695d9",
+      "implementation": "0xDF213Ee661238df4b29ae6d4b2DFF33d4E0BD7BE",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0xfCBF369998693b075837234706DD9453c3563D02",
+      "proxyDeploymentBlock": 43610314,
+      "implementationDeploymentBlock": 43610274,
+      "implementationActivationBlock": 43610314,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x1688027f0f95a19e0a5cba50696f8b1805fb96d12bc8fd70f838572be39ac907"
+    },
+    "reporter": {
+      "repository": "UMAprotocol/managed-oracle",
+      "artifact": "pm-v2-oo-reporter/src/OOReporter.sol:OOReporter",
+      "sourcePath": "pm-v2-oo-reporter/src/OOReporter.sol",
+      "sourceBlob": "72756488227bb0a59981bcf59931bc312e1706f6",
+      "deploymentRecordRevision": "baced1c9b54e50fda63cec16c7ee4015776eaa5f",
+      "sourceRevision": "13dabea4bc01d8a399f47e6dd29cb1e8ea12e01b",
+      "abiRevision": "13dabea4bc01d8a399f47e6dd29cb1e8ea12e01b",
+      "proxyType": "OpenZeppelin ERC1967Proxy UUPS",
+      "proxy": "0x9C1C617BC507E9dc08f7A0Dc8cf52431D18dB557",
+      "implementation": "0xA9588d8684b1e44bE8937630A4248C826028d9d7",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+      "proxyDeploymentBlock": 43496892,
+      "implementationDeploymentBlock": 43496889,
+      "implementationActivationBlock": 43496892,
+      "proxyCodehash": "0xe7fa925557fdbecea847ecb60e3d12c8bd9c18e0235ecba786ac6cd9eb6cbd7e",
+      "implementationCodehash": "0x452bc2958290ddb7252f4bba77025b98629feec2419a3072bef879be60a0907a"
+    },
+    "managedOracle": {
+      "repository": "UMAprotocol/managed-oracle",
+      "artifact": "src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol:ManagedOptimisticOracleV2",
+      "sourcePath": "src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol",
+      "sourceBlob": "a7059d3edb6b08bcaa88401aeac28c8dc27cbc27",
+      "deploymentRecordRevision": "",
+      "sourceRevision": "13dabea4bc01d8a399f47e6dd29cb1e8ea12e01b",
+      "abiRevision": "13dabea4bc01d8a399f47e6dd29cb1e8ea12e01b",
+      "proxyType": "OpenZeppelin ERC1967Proxy UUPS",
+      "proxy": "0xa3dE5F042EFD4C732498883100A2d319BbB3c1A1",
+      "implementation": "0x48f19d723Ab50e5E143EeB0EA3A8F9AB0649c834",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+      "proxyDeploymentBlock": 24737019,
+      "implementationDeploymentBlock": 43494158,
+      "implementationActivationBlock": 43494158,
+      "proxyCodehash": "0x77ffdff2dced37bc5d5cfea25d4b224824bd47f84ff720cb831e085db6a8f1e9",
+      "implementationCodehash": "0xd2b506ee72cbdb482ca52735ee604c70b3bdfd2a1949c7e23a89f07bb446d63a"
+    },
+    "binaryModule": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/modules/BinaryModule.sol:BinaryModule",
+      "sourcePath": "src/modules/BinaryModule.sol",
+      "sourceBlob": "b5d50dab1f9141172fdb11cb9df17d899ce59692",
+      "deploymentRecordRevision": "81e913360987a32422abd303e2756bc2e659f537",
+      "sourceRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "abiRevision": "db276f08782df62805ac0a309c516488bf74da7d",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0x1000008dD9001B968442c1000017eaE6E0dA00Ba",
+      "implementation": "0x69f46E306f31D65934389cCE28c118C694932dEB",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0xfCBF369998693b075837234706DD9453c3563D02",
+      "proxyDeploymentBlock": 39064744,
+      "implementationDeploymentBlock": 43535469,
+      "implementationActivationBlock": 43536208,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x9a460c71c5a0067a039183ab65634b38935a2b44519c1c88feb2fd90d51668d4"
+    },
+    "rewardCurrency": {
+      "artifact": "external ERC20 reward currency",
+      "deploymentType": "standalone contract (non-ERC1967)",
+      "address": "0x87D6cFE8fcdc8B87480DEEAB4aee868C7D5252AE",
+      "deploymentBlock": 19341751,
+      "codehash": "0x357244a2f39ae62eb720fb3971a28c22e44d4fa66be4b770058b0d9f09b9fd76"
+    },
+    "requesterWhitelist": {
+      "artifact": "UMA AddressWhitelist",
+      "deploymentType": "standalone contract (non-ERC1967)",
+      "address": "0xAD285f02B6853a34660253C643d1c06aec4B1059",
+      "deploymentBlock": 25462013,
+      "codehash": "0x2e5b53990b7c5892bdad6bbeb42231b5353bbf18e4fa7d85f6536f0d6e93a7c3"
+    },
+    "defaultProposerWhitelist": {
+      "artifact": "UMA AddressWhitelist",
+      "deploymentType": "standalone contract (non-ERC1967)",
+      "address": "0xe9a7Dd675e57E40b7fCd23C0ab726A1f6446B7e7",
+      "deploymentBlock": 25461759,
+      "codehash": "0x2e5b53990b7c5892bdad6bbeb42231b5353bbf18e4fa7d85f6536f0d6e93a7c3"
+    }
+  },
+  "roles": {
+    "aggregatorOwner": "0xfCBF369998693b075837234706DD9453c3563D02",
+    "moduleOwner": "0xfCBF369998693b075837234706DD9453c3563D02",
+    "reporterOwner": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "reporterPendingOwner": "0x0000000000000000000000000000000000000000",
+    "managedOracleDefaultAdmin": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "managedOracleDefaultAdminDelay": 259200,
+    "managedOraclePendingDefaultAdmin": "0x0000000000000000000000000000000000000000",
+    "managedOraclePendingDefaultAdminSchedule": 0,
+    "requesterWhitelistOwner": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "defaultProposerWhitelistOwner": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "requiredAggregatorAdmins": [
+      "0xcA71EA69c54c163D17beB90BeB8D001E1Eb538A1"
+    ],
+    "requiredAggregatorOperators": [
+      "0xac9930b2ae455a671b62de86876a7e8587825294",
+      "0x8c7c1A80D8347Cc6315dBE8f1271A5ad8C5eA73c"
+    ],
+    "requiredModuleAdmins": [
+      "0xcA71EA69c54c163D17beB90BeB8D001E1Eb538A1"
+    ],
+    "requiredModuleOperators": [],
+    "requiredOracleInitializersAndProposers": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleConfigAdmins": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleRequestManagers": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleResolverAdmins": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleResolvers": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "disputerAndArbitratorModule": "0x8Ef9D6d668798b1f363b305D916F30739d2b0419"
+  },
+  "capabilities": {
+    "snapshotStateVerified": true,
+    "automaticReporterCallback": false,
+    "reporterTwoStepOwnership": false,
+    "fullLifecycleSimulation": false
+  },
+  "knownBlockers": [
+    "The deployed reporter is the base OOReporter and does not include the automatic Polymarket callback.",
+    "OOReporterModule has no operator. Its admin 0xcA71EA69c54c163D17beB90BeB8D001E1Eb538A1 can grant one after an operator address is selected.",
+    "The Amoy ManagedOO deployment has no versioned broadcast/build artifact. Its 13dabea4bc01d8a399f47e6dd29cb1e8ea12e01b source mapping is inferred; the onchain block and code hash are authoritative."
+  ]
+}

--- a/test/polymarket-v2/environments/vnet.json
+++ b/test/polymarket-v2/environments/vnet.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": 2,
+  "environment": "polymarket-v2-staging-vnet",
+  "purpose": "Deterministic local-fork replay of the post-audit Polymarket v2 oracle stack.",
+  "chainId": 137,
+  "rpcEnvironmentVariable": "FRO111_VNET_RPC_URL",
+  "explorer": {
+    "name": "Tenderly VNet dashboard",
+    "baseUrlEnvironmentVariable": "FRO111_VNET_EXPLORER_URL"
+  },
+  "snapshot": {
+    "blockNumber": 88102756,
+    "rpcBlockNumber": "0x5405764",
+    "blockHash": "0xe54e07757df3e49f3bfa531d525c63c7cef14c0219a6742845796461f4a5b6a2"
+  },
+  "sources": {
+    "managedOracle": "19e06f085d95cf18101c274205298b73dfc295f3",
+    "managedOracleDeploymentTooling": "59f5f91271b3aac7c6fa1744fb84f407ad24980b",
+    "ooReporterDeploymentTooling": "7044bf9effe21de353b023e2426131ace9f0e826",
+    "polymarket": "11627f7629543e1efdcc2bb6ee0d7576834c4931",
+    "polymarketDeploymentConfig": "0896b9ed73cfb7fa3470c6822571ab0dce3d43f1"
+  },
+  "testAbiBundle": {
+    "path": "test/polymarket-v2/PolymarketV2Interfaces.sol",
+    "keccak256": "0x6e410ef356da3aeba25137466b2e6768d560c1128a4a5294337b7c5c9748eed3"
+  },
+  "contracts": {
+    "aggregator": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/oracle/OracleAggregator.sol:OracleAggregator",
+      "sourcePath": "src/oracle/OracleAggregator.sol",
+      "sourceBlob": "353fef3e0e999a22d05776a9ad2d6f1247c47392",
+      "deploymentRecordRevision": "2f2d6fb8122ce3c59143307455572795191eaa52",
+      "sourceRevision": "047ec3557535c2afbc5350c7e9a59244541f6c8e",
+      "abiRevision": "047ec3557535c2afbc5350c7e9a59244541f6c8e",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0x0A0a0A0A8B00C51b7D810501b03F230028C04a87",
+      "implementation": "0x1998bfA62C8A705A2283cFE52EBD095c95b0C594",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x47EbFAC3353314C788B96CDCbf41daadfE03629C",
+      "proxyDeploymentBlock": 87623475,
+      "implementationDeploymentBlock": 87539275,
+      "implementationActivationBlock": 87623475,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x3e372ad260ad63c29d52cd7e2047f172756816d190602e9a2c277e3d5c336a0a"
+    },
+    "reporterModule": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/oracle/modules/OOReporterModule.sol:OOReporterModule",
+      "sourcePath": "src/oracle/modules/OOReporterModule.sol",
+      "sourceBlob": "8865093bda976cc4384a79c06c7c48011ffb0c81",
+      "deploymentRecordRevision": "2f2d6fb8122ce3c59143307455572795191eaa52",
+      "sourceRevision": "047ec3557535c2afbc5350c7e9a59244541f6c8e",
+      "abiRevision": "047ec3557535c2afbc5350c7e9a59244541f6c8e",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0xC955D42bBd36F909Cd457847c6e8d798872695d9",
+      "implementation": "0xD7AaDc0b0f7e9fC66Bf5a5De159062B156dD4303",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x47EbFAC3353314C788B96CDCbf41daadfE03629C",
+      "proxyDeploymentBlock": 87539431,
+      "implementationDeploymentBlock": 87539407,
+      "implementationActivationBlock": 87539431,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x149a4db9661eed75ba26b624d62a1c5b5f6ed09afc6dcba28c89e0a2149edea2"
+    },
+    "reporter": {
+      "repository": "UMAprotocol/managed-oracle",
+      "artifact": "pm-v2-oo-reporter/src/PolymarketOOReporter.sol:PolymarketOOReporter",
+      "sourcePath": "pm-v2-oo-reporter/src/PolymarketOOReporter.sol",
+      "sourceBlob": "1520b4167abbc892be2522bbdfbcf4ffd41b66d8",
+      "deploymentRecordRevision": "a374b9e8bb3d7307325259e997c7958788f71f6b",
+      "sourceRevision": "19e06f085d95cf18101c274205298b73dfc295f3",
+      "abiRevision": "19e06f085d95cf18101c274205298b73dfc295f3",
+      "proxyType": "OpenZeppelin ERC1967Proxy UUPS",
+      "proxy": "0x2df52c80E4Fae386fc63EBfb550C64880848852c",
+      "implementation": "0xAbF22029DA4C523f67ac1d9fc42859e7b3dc809c",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+      "proxyDeploymentBlock": 87490526,
+      "implementationDeploymentBlock": 87939762,
+      "implementationActivationBlock": 87939763,
+      "proxyCodehash": "0xe7fa925557fdbecea847ecb60e3d12c8bd9c18e0235ecba786ac6cd9eb6cbd7e",
+      "implementationCodehash": "0xf88a0965a0997b5800b6f75c007bbeb1564f4d483832b677204db96357bf286f"
+    },
+    "managedOracle": {
+      "repository": "UMAprotocol/managed-oracle",
+      "artifact": "src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol:ManagedOptimisticOracleV2",
+      "sourcePath": "src/optimistic-oracle-v2/implementation/ManagedOptimisticOracleV2.sol",
+      "sourceBlob": "6fc07ab60ec1c66dafbed9fb129a5ae17f9fc216",
+      "deploymentRecordRevision": "fc007f973679f923f344c8300a2d370908172e67",
+      "sourceRevision": "19e06f085d95cf18101c274205298b73dfc295f3",
+      "abiRevision": "19e06f085d95cf18101c274205298b73dfc295f3",
+      "proxyType": "OpenZeppelin ERC1967Proxy UUPS",
+      "proxy": "0x2C0367a9DB231dDeBd88a94b4f6461a6e47C58B1",
+      "implementation": "0x9c790132BE86f0C1e59690d0e8C2B234ac74b3ca",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+      "proxyDeploymentBlock": 74677419,
+      "implementationDeploymentBlock": 87951455,
+      "implementationActivationBlock": 87951803,
+      "proxyCodehash": "0x77ffdff2dced37bc5d5cfea25d4b224824bd47f84ff720cb831e085db6a8f1e9",
+      "implementationCodehash": "0xce6d0c9c9e0aaae43f3141b4ea417a65a6e7875f489b0845c7568dc0822f1b78"
+    },
+    "binaryModule": {
+      "repository": "Polymarket/polymarket-v2",
+      "artifact": "src/modules/BinaryModule.sol:BinaryModule",
+      "sourcePath": "src/modules/BinaryModule.sol",
+      "sourceBlob": "f02675038e1be35c7b5d586b5d448abe54bcfa71",
+      "deploymentRecordRevision": "6428b128c4ef5aff04ecde1cbc3046f56797b508",
+      "sourceRevision": "6428b128c4ef5aff04ecde1cbc3046f56797b508",
+      "abiRevision": "6428b128c4ef5aff04ecde1cbc3046f56797b508",
+      "proxyType": "Solady LibClone ERC1967 UUPS",
+      "proxy": "0x1000008dD9001B968442c1000017eaE6E0dA00Ba",
+      "implementation": "0x492FEc596eC347459E1Ebe30b9245EB3B49B1BBa",
+      "proxyAdmin": "0x0000000000000000000000000000000000000000",
+      "upgradeAuthority": "0x47EbFAC3353314C788B96CDCbf41daadfE03629C",
+      "proxyDeploymentBlock": 85313858,
+      "implementationDeploymentBlock": 85313858,
+      "implementationActivationBlock": 87924763,
+      "proxyCodehash": "0xaaa52c8cc8a0e3fd27ce756cc6b4e70c51423e9b597b11f32d3e49f8b1fc890d",
+      "implementationCodehash": "0x4b5aa64364fc461b806cfb3b1e9d203fa52441e6415a3789313b266d961da7ae"
+    },
+    "rewardCurrency": {
+      "artifact": "external ERC20 reward currency",
+      "deploymentType": "legacy USDC.e proxy (non-ERC1967)",
+      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "deploymentBlock": 5013591,
+      "codehash": "0xa97604bff5b11d790aca38bf9f6189369ea260f08365b428fc2ef73390fddcef"
+    },
+    "requesterWhitelist": {
+      "artifact": "UMA AddressWhitelist",
+      "deploymentType": "standalone contract (non-ERC1967)",
+      "address": "0x0f79d0039956D58a7d5d006a6Dd64a35616Aa2c6",
+      "deploymentBlock": 74677192,
+      "codehash": "0x2d4153189ac6f7e0e098061ca41a95234700c66792e3a77bcf12b2fc15ca9e6a"
+    },
+    "defaultProposerWhitelist": {
+      "artifact": "UMA AddressWhitelist",
+      "deploymentType": "standalone contract (non-ERC1967)",
+      "address": "0x9F35885CE8f67a942D7B2f4Fbf937987DA08c463",
+      "deploymentBlock": 74676570,
+      "codehash": "0x2d4153189ac6f7e0e098061ca41a95234700c66792e3a77bcf12b2fc15ca9e6a"
+    }
+  },
+  "roles": {
+    "aggregatorOwner": "0x47EbFAC3353314C788B96CDCbf41daadfE03629C",
+    "moduleOwner": "0x47EbFAC3353314C788B96CDCbf41daadfE03629C",
+    "reporterOwner": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "reporterPendingOwner": "0x0000000000000000000000000000000000000000",
+    "managedOracleDefaultAdmin": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    "managedOracleDefaultAdminDelay": 259200,
+    "managedOraclePendingDefaultAdmin": "0x0000000000000000000000000000000000000000",
+    "managedOraclePendingDefaultAdminSchedule": 0,
+    "requesterWhitelistOwner": "0x3dcE0a29139A851Da1dFCa56Af8e8a6440b4D952",
+    "defaultProposerWhitelistOwner": "0x6ee4D971142afadEa1828445124D6137080B4146",
+    "requiredAggregatorAdmins": [
+      "0x3dcE0a29139A851Da1dFCa56Af8e8a6440b4D952"
+    ],
+    "requiredAggregatorOperators": [
+      "0x1b4133d01fd6c0ad09da7a5bcaabfcb965cef3f4",
+      "0xac9930b2ae455a671b62de86876a7e8587825294"
+    ],
+    "requiredModuleAdmins": [
+      "0x3dcE0a29139A851Da1dFCa56Af8e8a6440b4D952"
+    ],
+    "requiredModuleOperators": [
+      "0xac9930b2ae455a671b62de86876a7e8587825294"
+    ],
+    "requiredOracleInitializersAndProposers": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleConfigAdmins": [
+      "0x3dcE0a29139A851Da1dFCa56Af8e8a6440b4D952"
+    ],
+    "requiredManagedOracleRequestManagers": [
+      "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    ],
+    "requiredManagedOracleResolverAdmins": [
+      "0x6ee4D971142afadEa1828445124D6137080B4146"
+    ],
+    "requiredManagedOracleResolvers": [
+      "0x33965F7D08F61A62B86C1Ab9Be5d82C42F4c3081",
+      "0x9725e8172A108f2BaD87ef31eA4Ea729e939d869",
+      "0x561Cbe8b8022A9530D47478420EdfEB66b5c4720"
+    ],
+    "disputerAndArbitratorModule": "0x8Ef9D6d668798b1f363b305D916F30739d2b0419"
+  },
+  "capabilities": {
+    "snapshotStateVerified": true,
+    "automaticReporterCallback": true,
+    "reporterTwoStepOwnership": true,
+    "fullLifecycleSimulation": true
+  },
+  "knownBlockers": []
+}

--- a/test/polymarket-v2/evidence/amoy.md
+++ b/test/polymarket-v2/evidence/amoy.md
@@ -1,0 +1,28 @@
+# Amoy validation evidence
+
+- Validation date: 2026-08-05
+- Chain ID: 80002
+- Pinned block: 44,114,794
+- Pinned block hash: `0x2cb26d0bccddd8e93324a4f7d49646422caabb098b1a7a5239bba1e1e8a72593`
+- Execution: read-only RPC state plus Forge-local authorization call; no transaction submitted
+
+## Automated result
+
+`PolymarketV2AmoyWiringForkTest`: 3 passed against the exact snapshot using an archive-capable
+endpoint.
+
+- Snapshot hash, five proxy/implementation deployment and activation histories, plus first-code
+  blocks for the reward token and both whitelists.
+- Runtime hashes, UUPS/slots, owners, upgrade authorities, bindings, allowlists, role hierarchy,
+  admins, two aggregator operators, and Managed OO roles.
+- Unauthorized aggregator initialization rejected in the local fork.
+
+## Supported scope and blockers
+
+Amoy cannot run the automatic callback lifecycle because the reporter proxy points to base
+`OOReporter`, not `PolymarketOOReporter`. `OOReporterModule` also has no operator selected; its admin
+can grant one after the recipient is decided. Finally, the Managed OO deployment has no retained
+versioned broadcast/build artifact, so the source mapping is identified as an inference while its
+observed block, implementation slot, and code hash remain authoritative.
+
+These blockers do not affect the exact wiring and authorization subset above.

--- a/test/polymarket-v2/evidence/vnet.md
+++ b/test/polymarket-v2/evidence/vnet.md
@@ -1,0 +1,42 @@
+# Staging VNet validation evidence
+
+- Validation date: 2026-08-05
+- Chain ID: 137
+- Pinned block: 88,102,756
+- Pinned block hash: `0xe54e07757df3e49f3bfa531d525c63c7cef14c0219a6742845796461f4a5b6a2`
+- Fixture request ID: `0x018804eed8e0a0aaae200582e434c0b4f5000000000000000000000000000000`
+- Execution: deterministic Forge-local fork; no VNet transaction submitted
+
+## Automated result
+
+`PolymarketV2VNetWiringForkTest`: 3 passed.
+
+- Exact snapshot hash, five proxy/implementation first-code blocks, five current implementation
+  activation blocks, and first-code blocks for the reward token and both whitelists.
+- Runtime hashes, UUPS/slots, owners, upgrade authorities, bindings, allowlists, role hierarchy,
+  operational roles, and binary resolver permission.
+- Unauthorized aggregator initialization rejected.
+
+`PolymarketV2EndToEndForkTest`: 2 passed.
+
+- Full registration → UMA initialization → proposal → settlement → automatic callback →
+  Polymarket proposal/finalization → binary payout path.
+- Independent unauthorized-initialization regression.
+
+The final binary result was `[1_000_000, 0]`. Forge locally supplied the 500 USDC.e bond plus final
+fee; no remote balance changed.
+
+The BinaryModule's current implementation slot was restored by the VNet configuration at block
+87,924,763 without an `Upgraded` event. The history check pins that exact state transition rather
+than presenting it as a normal production upgrade.
+
+## Event evidence
+
+The E2E test captured and decoded Managed OO request/proposal/settlement, OOReporter
+registration/initialization/resolution/callback, module request/result, and aggregator
+initialization/vote/proposal/resolution events. It asserts their request IDs, actors, identifier,
+rules, liveness, reward/bond, timestamps, prices, payout, result arrays/hashes, votes, and resolver.
+The reusable field table is in `../README.md`.
+
+There is no transaction hash by design: every state transition and log was produced inside the
+local Forge EVM and discarded after the test.


### PR DESCRIPTION
## Summary

- Add versioned Staging VNet and Amoy manifests with deployment history, runtime hashes, UUPS topology, source/ABI provenance, ownership, roles, allowlists, and cross-contract bindings.
- Add read-only fork checks plus a full Forge-local VNet lifecycle from Polymarket request registration through Managed OO settlement, the reporter callback, aggregator finalization, and binary payout.
- Document reproducible setup, provenance checks, event evidence, funding/reset behavior, and the supported Amoy subset and blockers.

This targets `unaudited-pm-v2-oo-reporter` because the fixtures validate the post-audit integration currently proposed in #65.

## Validation

- `forge test --no-match-contract '.*Fork.*' -vv` — 83 passed
- `PolymarketV2ManifestTest` — 1 passed
- `PolymarketV2VNetWiringForkTest` — 3 passed
- `PolymarketV2EndToEndForkTest` — 2 passed
- `PolymarketV2AmoyWiringForkTest` at the pinned snapshot — 3 passed
- Amoy latest-state mode — 2 passed, 1 expected historical-check skip
- Clean environment without RPC variables — manifest passes, 8 fork tests skip explicitly
- Source, ABI, deployment-record, and Git-blob provenance check — passed

## Safety and environment scope

All lifecycle mutations run inside Forge's disposable local EVM. The suite contains no broadcast path, signer, private key, service credential, or remote impersonation/write method.

Amoy passes the exact wiring and authorization subset. Its automatic lifecycle remains blocked because the deployed reporter is the base `OOReporter` and `OOReporterModule` has no selected operator.

Linear: FRO-111